### PR TITLE
En 4907/arwen wasm namespacing

### DIFF
--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen/crypto"
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen/elrondapi"
+	"github.com/ElrondNetwork/arwen-wasm-vm/arwen/ethapi"
 	"github.com/ElrondNetwork/arwen-wasm-vm/config"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/ElrondNetwork/go-ext-wasm/wasmer"
@@ -74,11 +75,10 @@ func NewArwenVM(
 		return nil, err
 	}
 
-	// TODO: fix wasmer namespace conflicts, then uncomment
-	// imports, err = ethapi.EthereumImports(imports)
-	// if err != nil {
-	// 	return nil, err
-	// }
+	imports, err = ethapi.EthereumImports(imports)
+	if err != nil {
+		return nil, err
+	}
 
 	imports, err = crypto.CryptoImports(imports)
 	if err != nil {

--- a/arwen/crypto/cryptoei.go
+++ b/arwen/crypto/cryptoei.go
@@ -17,6 +17,7 @@ import (
 )
 
 func CryptoImports(imports *wasmer.Imports) (*wasmer.Imports, error) {
+	imports = imports.Namespace("env")
 	imports, err := imports.Append("sha256", sha256, C.sha256)
 	if err != nil {
 		return nil, err

--- a/arwen/elrondapi/bigintOps.go
+++ b/arwen/elrondapi/bigintOps.go
@@ -32,6 +32,8 @@ import (
 )
 
 func BigIntImports(imports *wasmer.Imports) (*wasmer.Imports, error) {
+	imports = imports.Namespace("bigint")
+
 	imports, err := imports.Append("bigIntNew", bigIntNew, C.bigIntNew)
 	if err != nil {
 		return nil, err

--- a/arwen/elrondapi/bigintOps.go
+++ b/arwen/elrondapi/bigintOps.go
@@ -32,7 +32,7 @@ import (
 )
 
 func BigIntImports(imports *wasmer.Imports) (*wasmer.Imports, error) {
-	imports = imports.Namespace("bigint")
+	imports = imports.Namespace("env")
 
 	imports, err := imports.Append("bigIntNew", bigIntNew, C.bigIntNew)
 	if err != nil {

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -52,6 +52,7 @@ import (
 
 func ElrondEImports() (*wasmer.Imports, error) {
 	imports := wasmer.NewImports()
+	imports = imports.Namespace("env")
 
 	imports, err := imports.Append("getOwner", getOwner, C.getOwner)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ElrondNetwork/elrond-vm-common v0.0.9
 	github.com/ElrondNetwork/elrond-vm-util v0.0.5
-	github.com/ElrondNetwork/go-ext-wasm v0.0.5
+	github.com/ElrondNetwork/go-ext-wasm v0.0.6
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.3.0
 )


### PR DESCRIPTION
* Specify `imports.Namespace("env")` for all Elrond EI imports (for elrondei, crypto and bigint imports).
* Specify `imports.Namespace("ethereum")` for Ethereum EI imports.
* Re-enable Ethereum API imports.