### PR TITLE
Minor fix in `checkForZeroUint64Fields()` for WASM Opcodes

### DIFF
--- a/config/gasSchedule.go
+++ b/config/gasSchedule.go
@@ -91,7 +91,7 @@ func checkForZeroUint64Fields(arg interface{}) error {
 	v := reflect.ValueOf(arg)
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
-		if field.Kind() != reflect.Uint64 {
+		if field.Kind() != reflect.Uint64 && field.Kind() != reflect.Uint32 {
 			continue
 		}
 		if field.Uint() == 0 {

--- a/config/gasSchedule_test.go
+++ b/config/gasSchedule_test.go
@@ -55,3 +55,23 @@ func TestDecode_ArwenGas(t *testing.T) {
 
 	fmt.Printf("%+v\n", ethOp)
 }
+
+func TestDecode_ZeroGasCostError(t *testing.T) {
+	gasMap := make(map[string]uint64)
+	gasMap = FillGasMapWithWASMOpcodeValues(gasMap, 1)
+
+	wasmCosts := &WASMOpcodeCost{}
+	err := mapstructure.Decode(gasMap, wasmCosts)
+	assert.Nil(t, err)
+
+	err = checkForZeroUint64Fields(*wasmCosts)
+	assert.Nil(t, err)
+
+	gasMap["BrIf"] = 0
+	wasmCosts = &WASMOpcodeCost{}
+	err = mapstructure.Decode(gasMap, wasmCosts)
+	assert.Nil(t, err)
+
+	err = checkForZeroUint64Fields(*wasmCosts)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Previously, `checkForZeroUint64Fields()` only looked at `uint64` fields. This PR enables `uint32` checks as well, required for WASM Opcodes (which are defined as `uint32`).