### PR TITLE
EN-4822/wasmer-reusing-resources

### DIFF
--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -150,7 +150,7 @@ func (host *vmContext) RunSmartContractCreate(input *vmcommon.ContractCreateInpu
 		return host.createVMOutputInCaseOfError(vmcommon.ContractInvalid), nil
 	}
 
-	defer host.instance.Close()
+	defer host.instance.Clean()
 
 	idContext := arwen.AddHostContext(host)
 	host.instance.SetContextData(unsafe.Pointer(&idContext))

--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -134,6 +134,9 @@ func (host *vmContext) RunSmartContractCreate(input *vmcommon.ContractCreateInpu
 	host.addTxValueToSmartContract(input.CallValue, address)
 
 	gasLeft := input.GasProvided.Int64()
+	// take out contract creation gas
+	gasLeft = gasLeft - int64(len(input.ContractCode))
+
 	opcode_costs := host.GasSchedule().WASMOpcodeCost.ToOpcodeCostsArray()
 	host.instance, err = wasmer.NewMeteredInstanceWithImportObject(input.ContractCode, &host.importObject, uint64(gasLeft), &opcode_costs)
 	if err != nil {
@@ -157,9 +160,6 @@ func (host *vmContext) RunSmartContractCreate(input *vmcommon.ContractCreateInpu
 		convertedResult := arwen.ConvertReturnValue(out)
 		result = convertedResult.Bytes()
 	}
-
-	// take out contract creation gas
-	gasLeft = gasLeft - int64(len(input.ContractCode))
 
 	newSCAcc, ok := host.outputAccounts[string(address)]
 	if !ok {

--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -176,6 +176,7 @@ func (host *vmContext) RunSmartContractCreate(input *vmcommon.ContractCreateInpu
 
 	arwen.RemoveHostContext(idContext)
 
+	gasLeft = gasLeft - int64(host.instance.GetPointsUsed())
 	vmOutput := host.createVMOutput(result, gasLeft)
 
 	return vmOutput, err

--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -200,7 +200,7 @@ func (host *vmContext) RunSmartContractCall(input *vmcommon.ContractCallInput) (
 		return host.createVMOutputInCaseOfError(vmcommon.ContractInvalid), nil
 	}
 
-	defer host.instance.Close()
+	defer host.instance.Clean()
 
 	idContext := arwen.AddHostContext(host)
 	host.instance.SetContextData(unsafe.Pointer(&idContext))

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ElrondNetwork/elrond-go v1.0.38 // indirect
 	github.com/ElrondNetwork/elrond-vm-common v0.1.1
 	github.com/ElrondNetwork/elrond-vm-util v0.0.7
-	github.com/ElrondNetwork/go-ext-wasm v0.0.8
+	github.com/ElrondNetwork/go-ext-wasm v0.0.9
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ElrondNetwork/elrond-go v1.0.38 // indirect
 	github.com/ElrondNetwork/elrond-vm-common v0.1.1
 	github.com/ElrondNetwork/elrond-vm-util v0.0.7
-	github.com/ElrondNetwork/go-ext-wasm v0.0.9
+	github.com/ElrondNetwork/go-ext-wasm v0.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,10 @@ module github.com/ElrondNetwork/arwen-wasm-vm
 go 1.13
 
 require (
+	github.com/ElrondNetwork/elrond-go v1.0.38 // indirect
 	github.com/ElrondNetwork/elrond-vm-common v0.1.1
 	github.com/ElrondNetwork/elrond-vm-util v0.0.7
-	github.com/ElrondNetwork/go-ext-wasm v0.0.7
+	github.com/ElrondNetwork/go-ext-wasm v0.0.8
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ElrondNetwork/arwen-wasm-vm
 go 1.13
 
 require (
-	github.com/ElrondNetwork/elrond-go v1.0.38 // indirect
 	github.com/ElrondNetwork/elrond-vm-common v0.1.1
 	github.com/ElrondNetwork/elrond-vm-util v0.0.7
 	github.com/ElrondNetwork/go-ext-wasm v0.1.0


### PR DESCRIPTION
The `VMContext` now stores a `wasmer.ImportObject` created during the initialization of the VM. The `ImportObject` is then passed to Wasmer whenever a SmartContract is called.