### PR TITLE
Implement invocation of ethereum "precompiled" (predefined) system contracts

### DIFF
--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -952,9 +952,8 @@ func (host *vmContext) ReturnData() [][]byte {
 	return host.returnData
 }
 
-func (host *vmContext) PutReturnData(data []byte) {
+func (host *vmContext) ClearReturnData() {
 	host.returnData = make([][]byte, 1)
-	host.returnData[0] = data
 }
 
 // The first four bytes is the method selector. The rest of the input data are method arguments in chunks of 32 bytes.

--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -464,11 +464,7 @@ func (host *vmContext) GetStorage(addr []byte, key []byte) []byte {
 		}
 	}
 
-	hash, err := host.blockChainHook.GetStorageData(addr, key)
-	if err != nil {
-		fmt.Printf("GetStorage returned with error %s \n", err.Error())
-	}
-
+	hash, _ := host.blockChainHook.GetStorageData(addr, key)
 	return hash
 }
 

--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -952,6 +952,11 @@ func (host *vmContext) ReturnData() [][]byte {
 	return host.returnData
 }
 
+func (host *vmContext) PutReturnData(data []byte) {
+	host.returnData = make([][]byte, 1)
+	host.returnData[0] = data
+}
+
 // The first four bytes is the method selector. The rest of the input data are method arguments in chunks of 32 bytes.
 // The method selector is the kecccak256 hash of the method signature.
 func (host *vmContext) createETHCallInput() []byte {

--- a/arwen/ethapi/ethereumei.go
+++ b/arwen/ethapi/ethereumei.go
@@ -495,6 +495,7 @@ func ethfinish(context unsafe.Pointer, resultOffset int32, length int32) {
 	ethContext := arwen.GetEthContext(instCtx.Data())
 
 	data := arwen.LoadBytes(instCtx.Memory(), resultOffset, length)
+	ethContext.ClearReturnData()
 	ethContext.Finish(data)
 
 	gasToUse := ethContext.GasSchedule().EthAPICost.Finish
@@ -508,6 +509,7 @@ func ethrevert(context unsafe.Pointer, dataOffset int32, length int32) {
 	ethContext := arwen.GetEthContext(instCtx.Data())
 
 	data := arwen.LoadBytes(instCtx.Memory(), dataOffset, length)
+	ethContext.ClearReturnData()
 	ethContext.Finish(data)
 	ethContext.SignalUserError()
 

--- a/arwen/ethapi/ethereumei.go
+++ b/arwen/ethapi/ethereumei.go
@@ -747,6 +747,15 @@ func ethcallStatic(context unsafe.Pointer, gasLimit int64, addressOffset int32, 
 		return 1
 	}
 
+	if IsAddressForPredefinedContract(address) {
+		err := CallPredefinedContract(context, address, data)
+		if err != nil {
+			return 1
+		}
+	
+		return 0
+	}
+
 	ethContext.Transfer(address, sender, value, nil)
 
 	ethContext.SetReadOnly(true)

--- a/arwen/ethapi/predefinedContracts.go
+++ b/arwen/ethapi/predefinedContracts.go
@@ -40,7 +40,8 @@ func CallPredefinedContract(ctx unsafe.Pointer, address []byte, data []byte) err
 		return fmt.Errorf("erroneous EEI system contract call: %s", err.Error())
 	}
 
-	ethCtx.PutReturnData(returnData)
+	ethCtx.ClearReturnData()
+	ethCtx.Finish(returnData)
 	return nil
 }
 

--- a/arwen/ethapi/predefinedContracts.go
+++ b/arwen/ethapi/predefinedContracts.go
@@ -1,0 +1,83 @@
+package ethapi
+
+import (
+	"encoding/hex"
+	"fmt"
+	"unsafe"
+
+	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
+	"github.com/ElrondNetwork/go-ext-wasm/wasmer"
+)
+
+// The mapping between system contracts and their addresses is defined here:
+// https://ewasm.readthedocs.io/en/mkdocs/system_contracts/
+var contractsMap = map[string]func(unsafe.Pointer, []byte) ([]byte, error){
+	"0000000000000000000000000000000000000001": ecrecover,
+	"0000000000000000000000000000000000000002": sha2,
+	"0000000000000000000000000000000000000003": ripemd160,
+	"0000000000000000000000000000000000000004": identity,
+	"0000000000000000000000000000000000000009": keccak256,
+}
+
+func IsAddressForPredefinedContract(address []byte) bool {
+	contractKey := hex.EncodeToString(address)
+	_, ok := contractsMap[contractKey]
+	return ok
+}
+
+func CallPredefinedContract(ctx unsafe.Pointer, address []byte, data []byte) error {
+	instCtx := wasmer.IntoInstanceContext(ctx)
+	ethCtx := arwen.GetEthContext(instCtx.Data())
+
+	contractKey := hex.EncodeToString(address)
+	contract, ok := contractsMap[contractKey]
+	if !ok {
+		return fmt.Errorf("invalid EEI system contract call - missing: %s", contractKey)
+	}
+
+	returnData, err := contract(ctx, data)
+	if err != nil {
+		return fmt.Errorf("erroneous EEI system contract call: %s", err.Error())
+	}
+
+	ethCtx.PutReturnData(returnData)
+	return nil
+}
+
+func ecrecover(context unsafe.Pointer, data []byte) ([]byte, error) {
+	return nil, fmt.Errorf("EEI system contract not implemented: ecrecover")
+}
+
+func sha2(context unsafe.Pointer, data []byte) ([]byte, error) {
+	instCtx := wasmer.IntoInstanceContext(context)
+	cryptoCtx := arwen.GetCryptoContext(instCtx.Data())
+
+	resultString, err := cryptoCtx.CryptoHooks().Sha256(string(data))
+	if err != nil {
+		return nil, err
+	}
+
+	result, _ := hex.DecodeString(resultString)
+	return result, nil
+}
+
+func ripemd160(context unsafe.Pointer, data []byte) ([]byte, error) {
+	return nil, fmt.Errorf("EEI system contract not implemented: ripemd160")
+}
+
+func identity(context unsafe.Pointer, data []byte) ([]byte, error) {
+	return nil, fmt.Errorf("EEI system contract not implemented: identity")
+}
+
+func keccak256(context unsafe.Pointer, data []byte) ([]byte, error) {
+	instCtx := wasmer.IntoInstanceContext(context)
+	cryptoCtx := arwen.GetCryptoContext(instCtx.Data())
+
+	resultString, err := cryptoCtx.CryptoHooks().Keccak256(string(data))
+	if err != nil {
+		return nil, err
+	}
+
+	result, _ := hex.DecodeString(resultString)
+	return result, nil
+}

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -27,6 +27,7 @@ type EthContext interface {
 	BlockChainHook() vmcommon.BlockchainHook
 	Transfer(destination []byte, sender []byte, value *big.Int, input []byte)
 	ReturnData() [][]byte
+	PutReturnData([]byte)
 
 	SetReadOnly(readOnly bool)
 	CreateNewContract(input *vmcommon.ContractCreateInput) ([]byte, error)
@@ -52,6 +53,7 @@ type HostContext interface {
 	BlockChainHook() vmcommon.BlockchainHook
 	SignalUserError()
 	ReturnData() [][]byte
+	PutReturnData([]byte)
 
 	SetReadOnly(readOnly bool)
 	CreateNewContract(input *vmcommon.ContractCreateInput) ([]byte, error)

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -27,7 +27,7 @@ type EthContext interface {
 	BlockChainHook() vmcommon.BlockchainHook
 	Transfer(destination []byte, sender []byte, value *big.Int, input []byte)
 	ReturnData() [][]byte
-	PutReturnData([]byte)
+	ClearReturnData()
 
 	SetReadOnly(readOnly bool)
 	CreateNewContract(input *vmcommon.ContractCreateInput) ([]byte, error)
@@ -53,7 +53,6 @@ type HostContext interface {
 	BlockChainHook() vmcommon.BlockchainHook
 	SignalUserError()
 	ReturnData() [][]byte
-	PutReturnData([]byte)
 
 	SetReadOnly(readOnly bool)
 	CreateNewContract(input *vmcommon.ContractCreateInput) ([]byte, error)


### PR DESCRIPTION
https://ewasm.readthedocs.io/en/mkdocs/system_contracts/

Also extend context interfaces with `ClearReturnData()`, which has to be called before `Finish()` for ETH / Solidity.