### PR TITLE
Handle invalid calls

### DIFF
--- a/arwen/context/arwen.go
+++ b/arwen/context/arwen.go
@@ -117,7 +117,20 @@ func NewArwenVM(
 	return context, nil
 }
 
-func (host *vmContext) RunSmartContractCreate(input *vmcommon.ContractCreateInput) (*vmcommon.VMOutput, error) {
+func (host *vmContext) RunSmartContractCreate(input *vmcommon.ContractCreateInput) (vmOutput *vmcommon.VMOutput, err error) {
+	try := func() {
+		vmOutput, err = host.doRunSmartContractCreate(input)
+	}
+
+	catch := func(caught error) {
+		err = caught
+	}
+
+	arwen.TryCatch(try, catch, "arwen.RunSmartContractCreate")
+	return
+}
+
+func (host *vmContext) doRunSmartContractCreate(input *vmcommon.ContractCreateInput) (*vmcommon.VMOutput, error) {
 	host.initInternalValues()
 	host.vmInput = input.VMInput
 
@@ -226,7 +239,20 @@ func (host *vmContext) callInitFunction() (bool, []byte, error) {
 	return true, result, nil
 }
 
-func (host *vmContext) RunSmartContractCall(input *vmcommon.ContractCallInput) (*vmcommon.VMOutput, error) {
+func (host *vmContext) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmOutput *vmcommon.VMOutput, err error) {
+	try := func() {
+		vmOutput, err = host.doRunSmartContractCall(input)
+	}
+
+	catch := func(caught error) {
+		err = caught
+	}
+
+	arwen.TryCatch(try, catch, "arwen.RunSmartContractCall")
+	return
+}
+
+func (host *vmContext) doRunSmartContractCall(input *vmcommon.ContractCallInput) (*vmcommon.VMOutput, error) {
 	host.initInternalValues()
 	host.vmInput = input.VMInput
 	host.scAddress = input.RecipientAddr

--- a/arwen/helpers.go
+++ b/arwen/helpers.go
@@ -196,3 +196,25 @@ func InverseBytes(data []byte) []byte {
 	}
 	return invBytes
 }
+
+// TryFunction corresponds to the try() part of a try / catch block
+type TryFunction func()
+
+// CatchFunction corresponds to the catch() part of a try / catch block
+type CatchFunction func(error)
+
+// TryCatch simulates a try/catch block using golang's recover() functionality
+func TryCatch(try TryFunction, catch CatchFunction, catchFallbackMessage string) {
+	defer func() {
+		if r := recover(); r != nil {
+			err, ok := r.(error)
+			if !ok {
+				err = fmt.Errorf("%s, panic: %v", catchFallbackMessage, r)
+			}
+
+			catch(err)
+		}
+	}()
+
+	try()
+}

--- a/arwen/helpers_test.go
+++ b/arwen/helpers_test.go
@@ -1,0 +1,80 @@
+package arwen
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_TryCatch_WorksWhenNoError(t *testing.T) {
+	tryCalled := false
+	catchCalled := false
+
+	try := func() {
+		tryCalled = true
+	}
+
+	catch := func(err error) {
+		catchCalled = true
+	}
+
+	TryCatch(try, catch, "message")
+
+	assert.True(t, tryCalled)
+	assert.False(t, catchCalled)
+}
+
+func Test_TryCatch_CatchesRuntimeError(t *testing.T) {
+	var caughtError error
+
+	try := func() {
+		bytes := make([]byte, 42)
+		// Causes runtime error.
+		bytes[42]++
+	}
+
+	catch := func(err error) {
+		caughtError = err
+	}
+
+	TryCatch(try, catch, "message")
+
+	assert.NotNil(t, caughtError)
+}
+
+func Test_TryCatch_CatchesCustomError(t *testing.T) {
+	var caughtError error
+
+	try := func() {
+		panic("untyped error")
+	}
+
+	catch := func(err error) {
+		caughtError = err
+	}
+
+	TryCatch(try, catch, "!thisMessage!")
+
+	assert.NotNil(t, caughtError)
+	assert.Contains(t, caughtError.Error(), "!thisMessage!")
+	assert.Contains(t, caughtError.Error(), "untyped error")
+}
+
+func Test_TryCatch_CatchesCustomErrorTyped(t *testing.T) {
+	var caughtError error
+	customError := fmt.Errorf("error")
+
+	try := func() {
+		panic(customError)
+	}
+
+	catch := func(err error) {
+		caughtError = err
+	}
+
+	TryCatch(try, catch, "!thisMessage!")
+
+	assert.NotNil(t, caughtError)
+	assert.Equal(t, customError, caughtError)
+}


### PR DESCRIPTION
Add global try/catch for deploy and run.
Will catch panics, but will not catch *unrecoverable runtime throws*.

References:
- https://blog.golang.org/defer-panic-and-recover
- https://github.com/golang/go/wiki/PanicAndRecover