### PR TITLE
Update vmcommon version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/ElrondNetwork/big-int-util v0.0.5
-	github.com/ElrondNetwork/elrond-vm-common v0.1.5
+	github.com/ElrondNetwork/elrond-vm-common v0.1.6
 	github.com/ElrondNetwork/elrond-vm-util v0.1.1
 	github.com/ElrondNetwork/go-ext-wasm v0.1.1
 	github.com/mitchellh/mapstructure v1.1.2


### PR DESCRIPTION
Update `go.mod` with the new `elrond-vm-common` release, after ArgumentParser has been moved from `elrond-go` into it.