### PR TITLE
Return early error in NewArwenDriver

### DIFF
--- a/cmd/arwen/main.go
+++ b/cmd/arwen/main.go
@@ -49,7 +49,8 @@ func doMain() (int, string) {
 
 	arwenArguments, err := common.GetArwenArguments(arwenInitFile)
 	if err != nil {
-		return common.ErrCodeInit, fmt.Sprintf("Cannot receive gasSchedule: %v", err)
+		// TODO: send message through "starting pipe" (ERR)
+		return common.ErrCodeInit, fmt.Sprintf("Cannot receive Arwen arguments: %v", err)
 	}
 
 	messagesMarshalizer := marshaling.CreateMarshalizer(arwenArguments.MessagesMarshalizer)
@@ -64,9 +65,11 @@ func doMain() (int, string) {
 		messagesMarshalizer,
 	)
 	if err != nil {
+		// TODO: send message through "starting pipe" (ERR)
 		return common.ErrCodeInit, fmt.Sprintf("Cannot create ArwenPart: %v", err)
 	}
 
+	// TODO: send message through "starting pipe" (OK)
 	err = part.StartLoop()
 	if err != nil {
 		return common.ErrCodeTerminated, fmt.Sprintf("Ended Arwen loop: %v", err)

--- a/ipc/nodepart/arwenDriver.go
+++ b/ipc/nodepart/arwenDriver.go
@@ -96,6 +96,8 @@ func (driver *ArwenDriver) startArwen() error {
 		return err
 	}
 
+	// TODO: wait for ACK (ERR / OK) message.
+
 	driver.part, err = NewNodePart(
 		driver.nodeLogger,
 		driver.arwenOutputRead,

--- a/ipc/tests/arwenDriver_test.go
+++ b/ipc/tests/arwenDriver_test.go
@@ -13,6 +13,32 @@ import (
 
 var arwenVirtualMachine = []byte{5, 0}
 
+func TestNewArwenDriver_ErrorWhenArwenError_BadGasSchedule(t *testing.T) {
+	t.Skip()
+
+	nodeLogger := logger.NewDefaultLogger(logger.LogTrace)
+	blockchain := &mock.BlockchainHookStub{}
+	badGasSchedule := config.MakeGasMap(1)
+	delete(badGasSchedule["BaseOperationCost"], "StorePerByte")
+
+	driver, err := nodepart.NewArwenDriver(
+		nodeLogger,
+		blockchain,
+		common.ArwenArguments{
+			VMHostArguments: common.VMHostArguments{
+				VMType:        arwenVirtualMachine,
+				BlockGasLimit: uint64(10000000),
+				GasSchedule:   badGasSchedule,
+			},
+			LogLevel: logger.LogTrace,
+		},
+		nodepart.Config{MaxLoopTime: 1000},
+	)
+
+	require.NotNil(t, err)
+	require.Nil(t, driver)
+}
+
 func TestArwenDriver_DiagnoseWait(t *testing.T) {
 	blockchain := &mock.BlockchainHookStub{}
 	driver := newDriver(t, blockchain)


### PR DESCRIPTION
If Arwen's process stops soon after its start - for example, in case of invalid parameters (invalid gas schedule) - then return error in `NewArwenDriver()`.

`ArwenDriver` waits for a confirmation message upon sending the initialization parameters to Arwen.

Issue reported by @bogdan-rosianu.