### PR TITLE
Fix Wasmer bridge

### DIFF
--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -210,7 +210,7 @@ func cWasmerInstanceCall(
 
 func cWasmerInstanceContextDataGet(instanceContext *cWasmerInstanceContextT) unsafe.Pointer {
 	return unsafe.Pointer(C.wasmer_instance_context_data_get(
-		(*C.wasmer_instance_t)(instanceContext),
+		(*C.wasmer_instance_context_t)(instanceContext),
 	))
 }
 


### PR DESCRIPTION
Fix wrong C-type cast in calling `wasmer_instance_context_data_get()`.