### PR TITLE
Fix golangci-lint issues

### DIFF
--- a/cmd/test/executorRun.go
+++ b/cmd/test/executorRun.go
@@ -163,7 +163,7 @@ func (te *arwenTestExecutor) Run(test *ij.Test) error {
 
 			if output.ReturnCode == vmi.Ok {
 				// subtract call value from sender (this is not reflected in the delta)
-				world.UpdateBalanceWithDelta(tx.From, big.NewInt(0).Neg(tx.Value))
+				_ = world.UpdateBalanceWithDelta(tx.From, big.NewInt(0).Neg(tx.Value))
 
 				accountsSlice := make([]*vmi.OutputAccount, len(output.OutputAccounts))
 				i := 0

--- a/cmd/test/testRunUtil.go
+++ b/cmd/test/testRunUtil.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 
-	twos "github.com/ElrondNetwork/big-int-util/twos-complement"
 	worldhook "github.com/ElrondNetwork/elrond-vm-util/mock-hook-blockchain"
 
 	vmi "github.com/ElrondNetwork/elrond-vm-common"
@@ -45,23 +44,6 @@ func convertLogToTestFormat(outputLog *vmi.LogEntry) *ij.LogEntry {
 	}
 
 	return &testLog
-}
-
-func convertArgument(arg *big.Int) []byte {
-	if arg.Sign() >= 0 {
-		return arg.Bytes()
-	}
-
-	return twos.ToBytes(arg)
-}
-
-var zero = big.NewInt(0)
-
-func zeroIfNil(i *big.Int) *big.Int {
-	if i == nil {
-		return zero
-	}
-	return i
 }
 
 func bigIntPretty(i *big.Int) string {

--- a/config/gasSchedule.go
+++ b/config/gasSchedule.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -96,7 +95,7 @@ func checkForZeroUint64Fields(arg interface{}) error {
 		}
 		if field.Uint() == 0 {
 			name := v.Type().Field(i).Name
-			return errors.New(fmt.Sprintf("Gas cost for operation %s has been set to 0 or is not set.", name))
+			return fmt.Errorf("Gas cost for operation %s has been set to 0 or is not set.", name)
 		}
 	}
 

--- a/config/gasSchedule_test.go
+++ b/config/gasSchedule_test.go
@@ -57,8 +57,7 @@ func TestDecode_ArwenGas(t *testing.T) {
 }
 
 func TestDecode_ZeroGasCostError(t *testing.T) {
-	gasMap := make(map[string]uint64)
-	gasMap = FillGasMap_WASMOpcodeValues(1)
+	gasMap := FillGasMap_WASMOpcodeValues(1)
 
 	wasmCosts := &WASMOpcodeCost{}
 	err := mapstructure.Decode(gasMap, wasmCosts)

--- a/ipc/arwenpart/part.go
+++ b/ipc/arwenpart/part.go
@@ -78,7 +78,11 @@ func (part *ArwenPart) doLoop() error {
 		response := part.replyToNodeRequest(request)
 
 		// Successful execution, send response
-		part.Messenger.SendContractResponse(response)
+		err = part.Messenger.SendContractResponse(response)
+		if err != nil {
+			return err
+		}
+
 		part.Messenger.ResetDialogue()
 	}
 }

--- a/ipc/nodepart/part.go
+++ b/ipc/nodepart/part.go
@@ -67,12 +67,16 @@ func (part *NodePart) noopReplier(message common.MessageHandler) common.MessageH
 
 // StartLoop runs the main loop
 func (part *NodePart) StartLoop(request common.MessageHandler) (common.MessageHandler, error) {
-	part.Messenger.SendContractRequest(request)
+	err := part.Messenger.SendContractRequest(request)
+	if err != nil {
+		return nil, err
+	}
+
 	response, err := part.doLoop()
 	if err != nil {
 		part.Logger.Error("[NODE]: end of loop", "err", err)
 	} else {
-		part.Logger.Debug("[NODE]: end of loop")
+		part.Logger.Trace("[NODE]: end of loop")
 	}
 
 	part.Messenger.ResetDialogue()

--- a/ipc/tests/arwenDriver_test.go
+++ b/ipc/tests/arwenDriver_test.go
@@ -64,7 +64,7 @@ func BenchmarkArwenDriver_RestartsIfStopped(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		driver.Close()
 		require.True(b, driver.IsClosed())
-		driver.RestartArwenIfNecessary()
+		_ = driver.RestartArwenIfNecessary()
 		require.False(b, driver.IsClosed())
 	}
 }
@@ -74,7 +74,7 @@ func BenchmarkArwenDriver_RestartArwenIfNecessary(b *testing.B) {
 	driver := newDriver(b, blockchain)
 
 	for i := 0; i < b.N; i++ {
-		driver.RestartArwenIfNecessary()
+		_ = driver.RestartArwenIfNecessary()
 	}
 }
 

--- a/ipc/tests/arwenPart_test.go
+++ b/ipc/tests/arwenPart_test.go
@@ -81,7 +81,7 @@ func doContractRequest(
 			marshaling.CreateMarshalizer(marshaling.JSON),
 		)
 		assert.Nil(t, err)
-		part.StartLoop()
+		_ = part.StartLoop()
 		wg.Done()
 	}()
 
@@ -96,7 +96,7 @@ func doContractRequest(
 		)
 		assert.Nil(t, err)
 		response, responseError = part.StartLoop(request)
-		part.SendStopSignal()
+		_ = part.SendStopSignal()
 		wg.Done()
 	}()
 

--- a/mock/blockChainHookMock.go
+++ b/mock/blockChainHookMock.go
@@ -69,7 +69,7 @@ func (b *BlockchainHookMock) AccountExists(address []byte) (bool, error) {
 	}
 
 	account, ok := b.Accounts[string(address)]
-	if ok == false {
+	if !ok {
 		return false, nil
 	}
 
@@ -102,7 +102,7 @@ func (b *BlockchainHookMock) GetBalance(address []byte) (*big.Int, error) {
 	}
 
 	account, ok := b.Accounts[string(address)]
-	if ok == false {
+	if !ok {
 		return nil, ErrAccountDoesntExist
 	}
 
@@ -110,7 +110,7 @@ func (b *BlockchainHookMock) GetBalance(address []byte) (*big.Int, error) {
 		return nil, account.Err
 	}
 
-	if account.Exists == false {
+	if !account.Exists {
 		return nil, ErrAccountDoesntExist
 	}
 
@@ -123,7 +123,7 @@ func (b *BlockchainHookMock) GetNonce(address []byte) (uint64, error) {
 	}
 
 	account, ok := b.Accounts[string(address)]
-	if ok == false {
+	if !ok {
 		return 0, ErrAccountDoesntExist
 	}
 
@@ -140,7 +140,7 @@ func (b *BlockchainHookMock) GetStorageData(address []byte, index []byte) ([]byt
 	}
 
 	account, ok := b.Accounts[string(address)]
-	if ok == false {
+	if !ok {
 		return []byte{}, ErrAccountDoesntExist
 	}
 
@@ -157,7 +157,7 @@ func (b *BlockchainHookMock) IsCodeEmpty(address []byte) (bool, error) {
 	}
 
 	account, ok := b.Accounts[string(address)]
-	if ok == false {
+	if !ok {
 		return false, ErrAccountDoesntExist
 	}
 
@@ -175,7 +175,7 @@ func (b *BlockchainHookMock) GetCode(address []byte) ([]byte, error) {
 	}
 
 	account, ok := b.Accounts[string(address)]
-	if ok == false {
+	if !ok {
 		return []byte{}, ErrAccountDoesntExist
 	}
 

--- a/mock/vmHostMock.go
+++ b/mock/vmHostMock.go
@@ -66,11 +66,9 @@ func (host *VmHostMock) EthereumCallData() []byte {
 }
 
 func (host *VmHostMock) InitState() {
-	return
 }
 
 func (host *VmHostMock) PushState() {
-	return
 }
 
 func (host *VmHostMock) PopState() {

--- a/wasmer/function_wrapper_helpers.go
+++ b/wasmer/function_wrapper_helpers.go
@@ -168,21 +168,21 @@ func writeInt32ToWasmInputs(wasmInputs []cWasmerValueT, index int, value interfa
 	wasmInputs[index].tag = cWasmI32
 	var pointer = (*int32)(unsafe.Pointer(&wasmInputs[index].value))
 
-	switch value.(type) {
+	switch typedValue := value.(type) {
 	case int8:
-		*pointer = int32(value.(int8))
+		*pointer = int32(typedValue)
 	case uint8:
-		*pointer = int32(value.(uint8))
+		*pointer = int32(typedValue)
 	case int16:
-		*pointer = int32(value.(int16))
+		*pointer = int32(typedValue)
 	case uint16:
-		*pointer = int32(value.(uint16))
+		*pointer = int32(typedValue)
 	case int32:
-		*pointer = int32(value.(int32))
+		*pointer = int32(typedValue)
 	case int:
-		*pointer = int32(value.(int))
+		*pointer = int32(typedValue)
 	case uint:
-		*pointer = int32(value.(uint))
+		*pointer = int32(typedValue)
 	case Value:
 		var value = value.(Value)
 
@@ -202,25 +202,25 @@ func writeInt64ToWasmInputs(wasmInputs []cWasmerValueT, index int, value interfa
 	wasmInputs[index].tag = cWasmI64
 	var pointer = (*int64)(unsafe.Pointer(&wasmInputs[index].value))
 
-	switch value.(type) {
+	switch typedValue := value.(type) {
 	case int8:
-		*pointer = int64(value.(int8))
+		*pointer = int64(typedValue)
 	case uint8:
-		*pointer = int64(value.(uint8))
+		*pointer = int64(typedValue)
 	case int16:
-		*pointer = int64(value.(int16))
+		*pointer = int64(typedValue)
 	case uint16:
-		*pointer = int64(value.(uint16))
+		*pointer = int64(typedValue)
 	case int32:
-		*pointer = int64(value.(int32))
+		*pointer = int64(typedValue)
 	case uint32:
-		*pointer = int64(value.(uint32))
+		*pointer = int64(typedValue)
 	case int64:
-		*pointer = int64(value.(int64))
+		*pointer = int64(typedValue)
 	case int:
-		*pointer = int64(value.(int))
+		*pointer = int64(typedValue)
 	case uint:
-		*pointer = int64(value.(uint))
+		*pointer = int64(typedValue)
 	case Value:
 		var value = value.(Value)
 
@@ -240,11 +240,11 @@ func writeFloat32ToWasmInputs(wasmInputs []cWasmerValueT, index int, value inter
 	wasmInputs[index].tag = cWasmF32
 	var pointer = (*float32)(unsafe.Pointer(&wasmInputs[index].value))
 
-	switch value.(type) {
+	switch typedValue := value.(type) {
 	case float32:
-		*pointer = value.(float32)
+		*pointer = typedValue
 	case Value:
-		var value = value.(Value)
+		var value = typedValue
 
 		if value.GetType() != TypeF32 {
 			return NewExportedFunctionError(exportedFunctionName, fmt.Sprintf("Argument #%d of the `%%s` exported function must be of type `f32`, cannot cast given value to this type.", index+1))
@@ -262,13 +262,13 @@ func writeFloat64ToWasmInputs(wasmInputs []cWasmerValueT, index int, value inter
 	wasmInputs[index].tag = cWasmF64
 	var pointer = (*float64)(unsafe.Pointer(&wasmInputs[index].value))
 
-	switch value.(type) {
+	switch typedValue := value.(type) {
 	case float32:
-		*pointer = float64(value.(float32))
+		*pointer = float64(typedValue)
 	case float64:
-		*pointer = value.(float64)
+		*pointer = typedValue
 	case Value:
-		var value = value.(Value)
+		var value = typedValue
 
 		if value.GetType() != TypeF64 {
 			return NewExportedFunctionError(exportedFunctionName, fmt.Sprintf("Argument #%d of the `%%s` exported function must be of type `f64`, cannot cast given value to this type.", index+1))

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -137,7 +137,7 @@ func newInstance(c_instance *cWasmerInstanceT) (*Instance, error) {
 	var emptyInstance = &Instance{instance: nil, Exports: nil, Memory: nil}
 
 	var wasmExports *cWasmerExportsT
-	var hasMemory = false
+	var hasMemory bool
 
 	cWasmerInstanceExports(c_instance, &wasmExports)
 	defer cWasmerExportsDestroy(wasmExports)
@@ -152,7 +152,7 @@ func newInstance(c_instance *cWasmerInstanceT) (*Instance, error) {
 		return emptyInstance, err
 	}
 
-	if hasMemory == false {
+	if !hasMemory {
 		return &Instance{instance: c_instance, Exports: exports, Memory: nil}, nil
 	}
 


### PR DESCRIPTION
Fix issues reported by `golangci-lint`.
CC @AdoAdoAdo.

Remaining (won't do):
```
SA1019: package golang.org/x/crypto/ripemd160 is deprecated: RIPEMD-160 is a legacy hash and should not be used for new applications. Also, this package does not and will not provide an optimized implementation. Instead, use a modern hash like SHA-256 (from crypto/sha256).  (staticcheck)
```

Reason: this obsolete hashing algorithm is listed as a EWASM "system contract".