### PR TITLE
Extra logs and measurements for Arwen OOP

### DIFF
--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -2,6 +2,7 @@ package contexts
 
 import (
 	"fmt"
+	"time"
 	"unsafe"
 
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
@@ -60,6 +61,8 @@ func (context *runtimeContext) InitState() {
 }
 
 func (context *runtimeContext) CreateWasmerInstance(contract []byte, gasLimit uint64) error {
+	defer arwen.TimeTrack(time.Now(), "CreateWasmerInstance")
+
 	var err error
 	context.instance, err = wasmer.NewMeteredInstance(contract, gasLimit)
 	if err != nil {

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -2,7 +2,6 @@ package contexts
 
 import (
 	"fmt"
-	"time"
 	"unsafe"
 
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
@@ -61,8 +60,6 @@ func (context *runtimeContext) InitState() {
 }
 
 func (context *runtimeContext) CreateWasmerInstance(contract []byte, gasLimit uint64) error {
-	defer arwen.TimeTrack(time.Now(), "CreateWasmerInstance")
-
 	var err error
 	context.instance, err = wasmer.NewMeteredInstance(contract, gasLimit)
 	if err != nil {

--- a/arwen/helpers.go
+++ b/arwen/helpers.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"path/filepath"
+	"time"
 	"unsafe"
 )
 
@@ -85,4 +86,9 @@ func GetSCCode(fileName string) []byte {
 	code, _ := ioutil.ReadFile(filepath.Clean(fileName))
 
 	return code
+}
+
+func TimeTrack(start time.Time, message string) {
+	elapsed := time.Since(start)
+	fmt.Println(message, "duration", elapsed)
 }

--- a/cmd/arwen/main.go
+++ b/cmd/arwen/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	fileDescriptorArwenInit   = 3
-	fileDescriptorNodeToArwen = 4
-	fileDescriptorArwenToNode = 5
-	fileDescriptorLogToNode   = 6
+	fileDescriptorArwenInit         = 3
+	fileDescriptorNodeToArwen       = 4
+	fileDescriptorArwenToNode       = 5
+	fileDescriptorMainLogToNode     = 6
+	fileDescriptorDialogueLogToNode = 6
 )
 
 func main() {
@@ -42,9 +43,14 @@ func doMain() (int, string) {
 		return common.ErrCodeCannotCreateFile, "Cannot get pipe file: [arwenToNodeFile]"
 	}
 
-	logToNodeFile := getPipeFile(fileDescriptorLogToNode)
-	if logToNodeFile == nil {
-		return common.ErrCodeCannotCreateFile, "Cannot get pipe file: [logToNodeFile]"
+	mainLogToNodeFile := getPipeFile(fileDescriptorMainLogToNode)
+	if mainLogToNodeFile == nil {
+		return common.ErrCodeCannotCreateFile, "Cannot get pipe file: [mainLogToNodeFile]"
+	}
+
+	dialogueLogToNodeFile := getPipeFile(fileDescriptorDialogueLogToNode)
+	if dialogueLogToNodeFile == nil {
+		return common.ErrCodeCannotCreateFile, "Cannot get pipe file: [dialogueLogToNodeFile]"
 	}
 
 	arwenArguments, err := common.GetArwenArguments(arwenInitFile)
@@ -54,10 +60,12 @@ func doMain() (int, string) {
 
 	messagesMarshalizer := marshaling.CreateMarshalizer(arwenArguments.MessagesMarshalizer)
 	logsMarshalizer := marshaling.CreateMarshalizer(arwenArguments.LogsMarshalizer)
-	arwenLogger := logger.NewPipeLogger(arwenArguments.LogLevel, logToNodeFile, logsMarshalizer)
+	mainLogger := logger.NewPipeLogger(arwenArguments.MainLogLevel, mainLogToNodeFile, logsMarshalizer)
+	dialogueLogger := logger.NewPipeLogger(arwenArguments.DialogueLogLevel, dialogueLogToNodeFile, logsMarshalizer)
 
 	part, err := arwenpart.NewArwenPart(
-		arwenLogger,
+		mainLogger,
+		dialogueLogger,
 		nodeToArwenFile,
 		arwenToNodeFile,
 		&arwenArguments.VMHostArguments,

--- a/cmd/arwen/main.go
+++ b/cmd/arwen/main.go
@@ -15,7 +15,7 @@ const (
 	fileDescriptorNodeToArwen       = 4
 	fileDescriptorArwenToNode       = 5
 	fileDescriptorMainLogToNode     = 6
-	fileDescriptorDialogueLogToNode = 6
+	fileDescriptorDialogueLogToNode = 7
 )
 
 func main() {

--- a/ipc/arwenpart/part.go
+++ b/ipc/arwenpart/part.go
@@ -85,7 +85,6 @@ func (part *ArwenPart) doLoop() error {
 }
 
 func (part *ArwenPart) replyToNodeRequest(request common.MessageHandler) common.MessageHandler {
-	part.Logger.Debug("[ARWEN]: replyToNodeRequest()", "req", request)
 	replier := part.Repliers[request.GetKind()]
 	return replier(request)
 }
@@ -99,7 +98,6 @@ func (part *ArwenPart) replyToRunSmartContractCreate(request common.MessageHandl
 func (part *ArwenPart) replyToRunSmartContractCall(request common.MessageHandler) common.MessageHandler {
 	typedRequest := request.(*common.MessageContractCallRequest)
 	vmOutput, err := part.VMHost.RunSmartContractCall(typedRequest.CallInput)
-	part.Logger.Debug("[ARWEN]: replyToRunSmartContractCall() done")
 	return common.NewMessageContractResponse(vmOutput, err)
 }
 

--- a/ipc/arwenpart/part.go
+++ b/ipc/arwenpart/part.go
@@ -21,13 +21,14 @@ type ArwenPart struct {
 
 // NewArwenPart creates the Arwen part
 func NewArwenPart(
-	logger logger.Logger,
+	mainLogger logger.Logger,
+	dialogueLogger logger.Logger,
 	input *os.File,
 	output *os.File,
 	vmHostArguments *common.VMHostArguments,
 	marshalizer marshaling.Marshalizer,
 ) (*ArwenPart, error) {
-	messenger := NewArwenMessenger(logger, input, output, marshalizer)
+	messenger := NewArwenMessenger(dialogueLogger, input, output, marshalizer)
 	blockchain := NewBlockchainHookGateway(messenger)
 	crypto := NewCryptoHookGateway()
 
@@ -38,7 +39,7 @@ func NewArwenPart(
 
 	part := &ArwenPart{
 		Messenger: messenger,
-		Logger:    logger,
+		Logger:    mainLogger,
 		VMHost:    host,
 	}
 

--- a/ipc/common/arguments.go
+++ b/ipc/common/arguments.go
@@ -10,16 +10,17 @@ import (
 // ArwenArguments represents the initialization arguments required by Arwen, passed through the initialization pipe
 type ArwenArguments struct {
 	VMHostArguments
-	LogLevel            logger.LogLevel
+	MainLogLevel        logger.LogLevel
+	DialogueLogLevel    logger.LogLevel
 	LogsMarshalizer     marshaling.MarshalizerKind
 	MessagesMarshalizer marshaling.MarshalizerKind
 }
 
 // VMHostArguments represents the arguments to be passed to VMHost
 type VMHostArguments struct {
-	VMType              []byte
-	BlockGasLimit       uint64
-	GasSchedule         GasScheduleMap
+	VMType        []byte
+	BlockGasLimit uint64
+	GasSchedule   GasScheduleMap
 }
 
 // GasScheduleMap is an alias

--- a/ipc/common/messages.go
+++ b/ipc/common/messages.go
@@ -120,6 +120,8 @@ type MessageHandler interface {
 	SetKind(kind MessageKind)
 	GetError() error
 	SetError(err error)
+	GetKindName() string
+	DebugString() string
 }
 
 // Message is the implementation of the abstraction
@@ -165,7 +167,14 @@ func (message *Message) SetError(err error) {
 	}
 }
 
-func (message *Message) String() string {
+// GetKindName gets the kind name
+func (message *Message) GetKindName() string {
+	kindName := messageKindNameByID[message.Kind]
+	return kindName
+}
+
+// DebugString is a debug representation of the message
+func (message *Message) DebugString() string {
 	kindName := messageKindNameByID[message.Kind]
 	return fmt.Sprintf("[kind=%s nonce=%d err=%s]", kindName, message.DialogueNonce, message.ErrorMessage)
 }

--- a/ipc/common/messenger.go
+++ b/ipc/common/messenger.go
@@ -42,7 +42,7 @@ func (messenger *Messenger) Send(message MessageHandler) error {
 	messenger.Nonce++
 	message.SetNonce(messenger.Nonce)
 	length, err := messenger.sender.Send(message)
-	messenger.Logger.Trace(fmt.Sprintf("[%s][#%d]: SENT message", messenger.Name, message.GetNonce()), "size", length, "msg", message)
+	messenger.Logger.Trace(fmt.Sprintf("[%s][#%d]: SENT message", messenger.Name, message.GetNonce()), "size", length, "msg", message.DebugString())
 	return err
 }
 
@@ -54,7 +54,7 @@ func (messenger *Messenger) Receive(timeout int) (MessageHandler, error) {
 		return nil, err
 	}
 
-	messenger.Logger.Trace(fmt.Sprintf("[%s][#%d]: RECEIVED message", messenger.Name, message.GetNonce()), "size", length, "msg", message)
+	messenger.Logger.Trace(fmt.Sprintf("[%s][#%d]: RECEIVED message", messenger.Name, message.GetNonce()), "size", length, "msg", message.DebugString())
 	messageNonce := message.GetNonce()
 	if messageNonce != messenger.Nonce+1 {
 		return nil, ErrInvalidMessageNonce

--- a/ipc/nodepart/arwenDriver.go
+++ b/ipc/nodepart/arwenDriver.go
@@ -369,7 +369,7 @@ func (driver *ArwenDriver) continuouslyCopyArwenLogs(arwenStdout io.Reader, arwe
 			}
 
 			line = strings.TrimSpace(line)
-			driver.arwenMainLogger.Info("ARWEN-OUT", "line", line)
+			driver.arwenMainLogger.Trace("ARWEN-OUT", "line", line)
 		}
 	}()
 

--- a/ipc/nodepart/arwenDriver.go
+++ b/ipc/nodepart/arwenDriver.go
@@ -385,21 +385,16 @@ func (driver *ArwenDriver) continuouslyCopyArwenLogs(arwenStdout io.Reader, arwe
 		}
 	}()
 
-	go func() {
-		for {
-			err := logger.ReceiveLogThroughPipe(driver.arwenMainLogger, arwenLog, driver.logsMarshalizer)
-			if err != nil {
-				driver.driverLogger.Error("ReceiveLogThroughPipe error (arwenMainLogger)", "err", err)
-				break
-			}
-		}
-	}()
+	driver.continuouslyCopyPipeToLog(arwenLog, driver.arwenMainLogger)
+	driver.continuouslyCopyPipeToLog(dialogueLog, driver.dialogueLogger)
+}
 
+func (driver *ArwenDriver) continuouslyCopyPipeToLog(pipe *os.File, log logger.Logger) {
 	go func() {
 		for {
-			err := logger.ReceiveLogThroughPipe(driver.dialogueLogger, dialogueLog, driver.logsMarshalizer)
+			err := logger.ReceiveLogThroughPipe(log, pipe, driver.logsMarshalizer)
 			if err != nil {
-				driver.driverLogger.Error("ReceiveLogThroughPipe error (dialogueLogger)", "err", err)
+				driver.driverLogger.Error("continuouslyCopyPipeToLog error", "err", err)
 				break
 			}
 		}

--- a/ipc/nodepart/arwenDriver.go
+++ b/ipc/nodepart/arwenDriver.go
@@ -20,7 +20,9 @@ var _ vmcommon.VMExecutionHandler = (*ArwenDriver)(nil)
 
 // ArwenDriver manages the execution of the Arwen process
 type ArwenDriver struct {
-	nodeLogger          logger.Logger
+	driverLogger        logger.Logger
+	arwenMainLogger     logger.Logger
+	dialogueLogger      logger.Logger
 	blockchainHook      vmcommon.BlockchainHook
 	arwenArguments      common.ArwenArguments
 	config              Config
@@ -33,21 +35,30 @@ type ArwenDriver struct {
 	arwenInputWrite  *os.File
 	arwenOutputRead  *os.File
 	arwenOutputWrite *os.File
+
+	// TODO: Encapsulate to PipeLoggerSinkPart / PipeLoggerSourcePart
 	arwenLogRead     *os.File
 	arwenLogWrite    *os.File
-	command          *exec.Cmd
-	part             *NodePart
+	dialogueLogRead  *os.File
+	dialogueLogWrite *os.File
+
+	command *exec.Cmd
+	part    *NodePart
 }
 
 // NewArwenDriver creates a new driver
 func NewArwenDriver(
-	nodeLogger logger.Logger,
+	driverLogger logger.Logger,
+	arwenMainLogger logger.Logger,
+	dialogueLogger logger.Logger,
 	blockchainHook vmcommon.BlockchainHook,
 	arwenArguments common.ArwenArguments,
 	config Config,
 ) (*ArwenDriver, error) {
 	driver := &ArwenDriver{
-		nodeLogger:          nodeLogger,
+		driverLogger:        driverLogger,
+		arwenMainLogger:     arwenMainLogger,
+		dialogueLogger:      dialogueLogger,
 		blockchainHook:      blockchainHook,
 		arwenArguments:      arwenArguments,
 		config:              config,
@@ -64,7 +75,7 @@ func NewArwenDriver(
 }
 
 func (driver *ArwenDriver) startArwen() error {
-	driver.nodeLogger.Info("ArwenDriver.startArwen()")
+	driver.driverLogger.Info("ArwenDriver.startArwen()")
 
 	driver.resetPipeStreams()
 
@@ -74,7 +85,13 @@ func (driver *ArwenDriver) startArwen() error {
 	}
 
 	driver.command = exec.Command(arwenPath)
-	driver.command.ExtraFiles = []*os.File{driver.arwenInitRead, driver.arwenInputRead, driver.arwenOutputWrite, driver.arwenLogWrite}
+	driver.command.ExtraFiles = []*os.File{
+		driver.arwenInitRead,
+		driver.arwenInputRead,
+		driver.arwenOutputWrite,
+		driver.arwenLogWrite,
+		driver.dialogueLogWrite,
+	}
 
 	arwenStdout, err := driver.command.StdoutPipe()
 	if err != nil {
@@ -97,7 +114,8 @@ func (driver *ArwenDriver) startArwen() error {
 	}
 
 	driver.part, err = NewNodePart(
-		driver.nodeLogger,
+		driver.driverLogger,
+		driver.dialogueLogger,
 		driver.arwenOutputRead,
 		driver.arwenInputWrite,
 		driver.blockchainHook,
@@ -166,8 +184,12 @@ func (driver *ArwenDriver) resetPipeStreams() error {
 	closeFile(driver.arwenInputWrite)
 	closeFile(driver.arwenOutputRead)
 	closeFile(driver.arwenOutputWrite)
+
+	// TODO: Encapsulate logger-pipes (see above TODO)
 	closeFile(driver.arwenLogRead)
 	closeFile(driver.arwenLogWrite)
+	closeFile(driver.dialogueLogRead)
+	closeFile(driver.dialogueLogWrite)
 
 	var err error
 
@@ -187,6 +209,11 @@ func (driver *ArwenDriver) resetPipeStreams() error {
 	}
 
 	driver.arwenLogRead, driver.arwenLogWrite, err = os.Pipe()
+	if err != nil {
+		return err
+	}
+
+	driver.dialogueLogRead, driver.dialogueLogWrite, err = os.Pipe()
 	if err != nil {
 		return err
 	}
@@ -231,7 +258,7 @@ func (driver *ArwenDriver) IsClosed() bool {
 
 // RunSmartContractCreate sends a deploy request to Arwen and waits for the output
 func (driver *ArwenDriver) RunSmartContractCreate(input *vmcommon.ContractCreateInput) (*vmcommon.VMOutput, error) {
-	driver.nodeLogger.Trace("RunSmartContractCreate")
+	driver.driverLogger.Trace("RunSmartContractCreate")
 	driver.RestartArwenIfNecessary()
 
 	request := common.NewMessageContractDeployRequest(input)
@@ -252,13 +279,13 @@ func (driver *ArwenDriver) RunSmartContractCreate(input *vmcommon.ContractCreate
 
 // RunSmartContractCall sends an execution request to Arwen and waits for the output
 func (driver *ArwenDriver) RunSmartContractCall(input *vmcommon.ContractCallInput) (*vmcommon.VMOutput, error) {
-	driver.nodeLogger.Trace("RunSmartContractCall", "sc", input.RecipientAddr)
+	driver.driverLogger.Trace("RunSmartContractCall", "sc", input.RecipientAddr)
 	driver.RestartArwenIfNecessary()
 
 	request := common.NewMessageContractCallRequest(input)
 	response, err := driver.part.StartLoop(request)
 	if err != nil {
-		driver.nodeLogger.Error("RunSmartContractCall", "err", err)
+		driver.driverLogger.Error("RunSmartContractCall", "err", err)
 		driver.stopArwen()
 		return nil, common.WrapCriticalError(err)
 	}
@@ -279,7 +306,7 @@ func (driver *ArwenDriver) DiagnoseWait(milliseconds uint32) error {
 	request := common.NewMessageDiagnoseWaitRequest(milliseconds)
 	response, err := driver.part.StartLoop(request)
 	if err != nil {
-		driver.nodeLogger.Error("RunSmartContractCall", "err", err)
+		driver.driverLogger.Error("RunSmartContractCall", "err", err)
 		driver.stopArwen()
 		return common.WrapCriticalError(err)
 	}
@@ -301,7 +328,7 @@ func (driver *ArwenDriver) stopArwen() error {
 	err := driver.command.Process.Kill()
 	driver.command.Process.Wait()
 	if err != nil {
-		driver.nodeLogger.Error("stopArwen error", "err", err)
+		driver.driverLogger.Error("stopArwen error", "err", err)
 	}
 
 	return err
@@ -311,6 +338,7 @@ func (driver *ArwenDriver) continuouslyCopyArwenLogs(arwenStdout io.Reader, arwe
 	stdoutReader := bufio.NewReader(arwenStdout)
 	stderrReader := bufio.NewReader(arwenStderr)
 	arwenLog := driver.arwenLogRead
+	dialogueLog := driver.dialogueLogRead
 
 	go func() {
 		for {
@@ -320,7 +348,7 @@ func (driver *ArwenDriver) continuouslyCopyArwenLogs(arwenStdout io.Reader, arwe
 			}
 
 			line = strings.TrimSpace(line)
-			driver.nodeLogger.Info("ARWEN-OUT", "line", line)
+			driver.arwenMainLogger.Info("ARWEN-OUT", "line", line)
 		}
 	}()
 
@@ -332,15 +360,25 @@ func (driver *ArwenDriver) continuouslyCopyArwenLogs(arwenStdout io.Reader, arwe
 			}
 
 			line = strings.TrimSpace(line)
-			driver.nodeLogger.Error("ARWEN-ERR", "line", line)
+			driver.arwenMainLogger.Error("ARWEN-ERR", "line", line)
 		}
 	}()
 
 	go func() {
 		for {
-			err := logger.ReceiveLogThroughPipe(driver.nodeLogger, arwenLog, driver.logsMarshalizer)
+			err := logger.ReceiveLogThroughPipe(driver.arwenMainLogger, arwenLog, driver.logsMarshalizer)
 			if err != nil {
-				driver.nodeLogger.Error("ReceiveLogThroughPipe error", "err", err)
+				driver.driverLogger.Error("ReceiveLogThroughPipe error (arwenMainLogger)", "err", err)
+				break
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			err := logger.ReceiveLogThroughPipe(driver.dialogueLogger, dialogueLog, driver.logsMarshalizer)
+			if err != nil {
+				driver.driverLogger.Error("ReceiveLogThroughPipe error (dialogueLogger)", "err", err)
 				break
 			}
 		}

--- a/ipc/nodepart/arwenDriver.go
+++ b/ipc/nodepart/arwenDriver.go
@@ -42,6 +42,9 @@ type ArwenDriver struct {
 	dialogueLogRead  *os.File
 	dialogueLogWrite *os.File
 
+	counterDeploy uint64
+	counterCall   uint64
+
 	command *exec.Cmd
 	part    *NodePart
 }
@@ -258,7 +261,9 @@ func (driver *ArwenDriver) IsClosed() bool {
 
 // RunSmartContractCreate sends a deploy request to Arwen and waits for the output
 func (driver *ArwenDriver) RunSmartContractCreate(input *vmcommon.ContractCreateInput) (*vmcommon.VMOutput, error) {
-	driver.driverLogger.Trace("RunSmartContractCreate")
+	driver.counterDeploy++
+
+	driver.driverLogger.Trace("RunSmartContractCreate", "counter", driver.counterDeploy)
 	driver.RestartArwenIfNecessary()
 
 	request := common.NewMessageContractDeployRequest(input)
@@ -279,7 +284,9 @@ func (driver *ArwenDriver) RunSmartContractCreate(input *vmcommon.ContractCreate
 
 // RunSmartContractCall sends an execution request to Arwen and waits for the output
 func (driver *ArwenDriver) RunSmartContractCall(input *vmcommon.ContractCallInput) (*vmcommon.VMOutput, error) {
-	driver.driverLogger.Trace("RunSmartContractCall", "sc", input.RecipientAddr)
+	driver.counterCall++
+
+	driver.driverLogger.Trace("RunSmartContractCall", "counter", driver.counterCall, "func", input.Function, "sc", input.RecipientAddr)
 	driver.RestartArwenIfNecessary()
 
 	request := common.NewMessageContractCallRequest(input)

--- a/ipc/nodepart/part.go
+++ b/ipc/nodepart/part.go
@@ -20,17 +20,18 @@ type NodePart struct {
 
 // NewNodePart creates the Node part
 func NewNodePart(
-	nodeLogger logger.Logger,
+	mainLogger logger.Logger,
+	dialogueLogger logger.Logger,
 	input *os.File,
 	output *os.File,
 	blockchain vmcommon.BlockchainHook,
 	config Config,
 	marshalizer marshaling.Marshalizer,
 ) (*NodePart, error) {
-	messenger := NewNodeMessenger(nodeLogger, input, output, marshalizer)
+	messenger := NewNodeMessenger(dialogueLogger, input, output, marshalizer)
 
 	part := &NodePart{
-		Logger:     nodeLogger,
+		Logger:     mainLogger,
 		Messenger:  messenger,
 		blockchain: blockchain,
 		config:     config,
@@ -72,7 +73,7 @@ func (part *NodePart) StartLoop(request common.MessageHandler) (common.MessageHa
 	if err != nil {
 		part.Logger.Error("[NODE]: end of loop", "err", err)
 	} else {
-		part.Logger.Debug("[NODE]: end of loop")
+		part.Logger.Trace("[NODE]: end of loop")
 	}
 
 	part.Messenger.ResetDialogue()

--- a/ipc/tests/arwenDriver_test.go
+++ b/ipc/tests/arwenDriver_test.go
@@ -79,9 +79,14 @@ func BenchmarkArwenDriver_RestartArwenIfNecessary(b *testing.B) {
 }
 
 func newDriver(tb testing.TB, blockchain *mock.BlockchainHookStub) *nodepart.ArwenDriver {
-	nodeLogger := logger.NewDefaultLogger(logger.LogDebug)
+	driverLogger := logger.NewDefaultLogger(logger.LogDebug)
+	arwenMainLogger := logger.NewDefaultLogger(logger.LogDebug)
+	dialogueLogger := logger.NewDefaultLogger(logger.LogDebug)
+
 	driver, err := nodepart.NewArwenDriver(
-		nodeLogger,
+		driverLogger,
+		arwenMainLogger,
+		dialogueLogger,
 		blockchain,
 		common.ArwenArguments{
 			VMHostArguments: common.VMHostArguments{
@@ -89,7 +94,8 @@ func newDriver(tb testing.TB, blockchain *mock.BlockchainHookStub) *nodepart.Arw
 				BlockGasLimit: uint64(10000000),
 				GasSchedule:   config.MakeGasMap(1),
 			},
-			LogLevel: logger.LogDebug,
+			MainLogLevel:     logger.LogDebug,
+			DialogueLogLevel: logger.LogDebug,
 		},
 		nodepart.Config{MaxLoopTime: 1000},
 	)

--- a/ipc/tests/arwenPart_test.go
+++ b/ipc/tests/arwenPart_test.go
@@ -64,7 +64,8 @@ func doContractRequest(
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 
-	logger := logger.NewDefaultLogger(logger.LogDebug)
+	mainLogger := logger.NewDefaultLogger(logger.LogDebug)
+	dialogueLogger := logger.NewDefaultLogger(logger.LogDebug)
 
 	go func() {
 		vmHostArguments := &common.VMHostArguments{
@@ -74,7 +75,8 @@ func doContractRequest(
 		}
 
 		part, err := arwenpart.NewArwenPart(
-			logger,
+			mainLogger,
+			dialogueLogger,
 			files.inputOfArwen,
 			files.outputOfArwen,
 			vmHostArguments,
@@ -87,7 +89,8 @@ func doContractRequest(
 
 	go func() {
 		part, err := nodepart.NewNodePart(
-			logger,
+			mainLogger,
+			dialogueLogger,
 			files.inputOfNode,
 			files.outputOfNode,
 			blockchain,


### PR DESCRIPTION
Separate loggers: driver logger (Node's process), main Arwen logger (Arwen's process), dialogue logger (both processes).

Added counts for deployed and executed (not kept between restarts, of course).

Added prints for Wasmer compilation phase (will be redirected to Arwen's main logger, with Trace).