### PR TITLE
Fix canExecuteSynchronously()

### DIFF
--- a/arwen/common.go
+++ b/arwen/common.go
@@ -16,6 +16,8 @@ const (
 	BreakpointOutOfGas
 )
 
+type AsyncCallExecutionMode uint
+
 const (
 	SyncCall AsyncCallExecutionMode = iota
 	AsyncBuiltinFunc

--- a/arwen/common.go
+++ b/arwen/common.go
@@ -16,6 +16,12 @@ const (
 	BreakpointOutOfGas
 )
 
+const (
+	SyncCall AsyncCallExecutionMode = iota
+	AsyncBuiltinFunc
+	AsyncUnknown
+)
+
 const CallbackDefault = "callBack"
 const TimeLockKeyPrefix = "timelock"
 const AsyncDataPrefix = "asyncCalls"
@@ -91,8 +97,8 @@ type AsyncContext struct {
 // AsyncContextInfo is the structure resulting after a smart contract call that has initiated
 // one or more async calls. It will
 type AsyncContextInfo struct {
-	CallerAddr []byte
-	ReturnData []byte
+	CallerAddr      []byte
+	ReturnData      []byte
 	AsyncContextMap map[string]*AsyncContext
 }
 
@@ -120,5 +126,3 @@ func (ac *AsyncGeneratedCall) GetValueBytes() []byte {
 func (ac *AsyncGeneratedCall) IsInterfaceNil() bool {
 	return ac == nil
 }
-
-

--- a/arwen/contexts/blockchain.go
+++ b/arwen/contexts/blockchain.go
@@ -119,11 +119,11 @@ func (context *blockchainContext) GetCodeHash(addr []byte) ([]byte, error) {
 
 func (context *blockchainContext) GetCode(address []byte) ([]byte, error) {
 	account, err := context.blockChainHook.GetUserAccount(address)
-	if arwen.IfNil(account) {
-		return nil, arwen.ErrInvalidAccount
-	}
 	if err != nil {
 		return nil, err
+	}
+	if arwen.IfNil(account) {
+		return nil, arwen.ErrInvalidAccount
 	}
 
 	code := account.GetCode()

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -700,13 +700,13 @@ func (host *vmHost) getCurrentAsyncInfo() (*arwen.AsyncContextInfo, error) {
 	runtime := host.Runtime()
 	storage := host.Storage()
 
+	asyncInfo := &arwen.AsyncContextInfo{}
 	storageKey := arwen.CustomStorageKey(arwen.AsyncDataPrefix, runtime.GetOriginalTxHash())
 	buff := storage.GetStorage(storageKey)
 	if len(buff) == 0 {
-		return nil, nil
+		return asyncInfo, nil
 	}
 
-	asyncInfo := &arwen.AsyncContextInfo{}
 	err := json.Unmarshal(buff, &asyncInfo)
 	if err != nil {
 		return nil, err

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -31,10 +31,16 @@ func (host *vmHost) handleAsyncCallBreakpoint() error {
 	// Cross-shard calls for built-in functions must be executed in both the
 	// sender and destination shards.
 	if execMode == arwen.AsyncBuiltinFunc {
-		_, err := host.executeSyncDestinationCall(asyncCallInfo)
+		builtinFuncVMOutput, err := host.executeSyncDestinationCall(asyncCallInfo)
 		if err != nil {
 			return err
 		}
+
+		err = host.processCallbackVMOutput(builtinFuncVMOutput, err)
+		if err != nil {
+			return err
+		}
+
 		return host.sendAsyncCallToDestination(asyncCallInfo)
 	}
 

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -525,6 +525,9 @@ func (host *vmHost) processCallbackStack() error {
 
 	storageKey := arwen.CustomStorageKey(arwen.AsyncDataPrefix, runtime.GetOriginalTxHash())
 	buff := storage.GetStorage(storageKey)
+	if len(buff) == 0 {
+		return nil
+	}
 
 	asyncInfo := &arwen.AsyncContextInfo{}
 	err := json.Unmarshal(buff, &asyncInfo)
@@ -693,6 +696,9 @@ func (host *vmHost) getCurrentAsyncInfo() (*arwen.AsyncContextInfo, error) {
 
 	storageKey := arwen.CustomStorageKey(arwen.AsyncDataPrefix, runtime.GetOriginalTxHash())
 	buff := storage.GetStorage(storageKey)
+	if len(buff) == 0 {
+		return nil, nil
+	}
 
 	asyncInfo := &arwen.AsyncContextInfo{}
 	err := json.Unmarshal(buff, &asyncInfo)

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -269,6 +269,10 @@ func (host *vmHost) isInitFunctionBeingCalled() bool {
 
 func (host *vmHost) isBuiltinFunctionBeingCalled() bool {
 	functionName := host.Runtime().Function()
+	return host.isBuiltinFunctionName(functionName)
+}
+
+func (host *vmHost) isBuiltinFunctionName(functionName string) bool {
 	_, ok := host.protocolBuiltinFunctions[functionName]
 	return ok
 }


### PR DESCRIPTION
Improve the method `host.canExecuteSynchronously()` to allow calls to built-in functions of regular accounts, i.e. accounts that don't hold smart contract code.