### PR TITLE
return error for empty code

### DIFF
--- a/arwen/contexts/blockchain.go
+++ b/arwen/contexts/blockchain.go
@@ -119,8 +119,16 @@ func (context *blockchainContext) GetCodeHash(addr []byte) ([]byte, error) {
 
 func (context *blockchainContext) GetCode(address []byte) ([]byte, error) {
 	account, err := context.blockChainHook.GetUserAccount(address)
-	if err != nil || arwen.IfNil(account) {
+	if arwen.IfNil(account) {
+		return nil, arwen.ErrInvalidAccount
+	}
+	if err != nil {
 		return nil, err
+	}
+
+	code := account.GetCode()
+	if len(code) == 0 {
+		return nil, arwen.ErrContractNotFound
 	}
 
 	return account.GetCode(), nil

--- a/arwen/errors.go
+++ b/arwen/errors.go
@@ -78,3 +78,5 @@ var ErrShiftNegative = errors.New("bitwise shift operations only allowed on posi
 var ErrAsyncContextDoesNotExist = errors.New("async context was not created yet")
 
 var ErrAsync = errors.New("invalid gas percentage provided for async call")
+
+var ErrInvalidAccount = errors.New("account does exist")

--- a/arwen/errors.go
+++ b/arwen/errors.go
@@ -79,4 +79,4 @@ var ErrAsyncContextDoesNotExist = errors.New("async context was not created yet"
 
 var ErrAsync = errors.New("invalid gas percentage provided for async call")
 
-var ErrInvalidAccount = errors.New("account does exist")
+var ErrInvalidAccount = errors.New("account does not exist")


### PR DESCRIPTION
Return error on `GetCode` if no code is there. This is because on the previous version of BlockchainHook, GetCode was called directly and that function was taking care of that check. Now, using `GetUserAccount` we need to take care of this check our selves. Also separated the error checks to remove the (small) chance of getting a `return nil, nil` 