### PR TITLE
Temporarily disable promises

### DIFF
--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -120,15 +120,15 @@ func ElrondEIImports() (*wasmer.Imports, error) {
 		return nil, err
 	}
 
-	imports, err = imports.Append("createAsyncCall", createAsyncCall, C.createAsyncCall)
-	if err != nil {
-		return nil, err
-	}
+	// imports, err = imports.Append("createAsyncCall", createAsyncCall, C.createAsyncCall)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	imports, err = imports.Append("setAsyncContextCallback", setAsyncContextCallback, C.setAsyncContextCallback)
-	if err != nil {
-		return nil, err
-	}
+	// imports, err = imports.Append("setAsyncContextCallback", setAsyncContextCallback, C.setAsyncContextCallback)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	imports, err = imports.Append("getArgumentLength", getArgumentLength, C.getArgumentLength)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ElrondNetwork/big-int-util v0.0.5
 	github.com/ElrondNetwork/elrond-go-logger v1.0.2
 	github.com/ElrondNetwork/elrond-vm-common v0.1.21
-	github.com/ElrondNetwork/elrond-vm-util v0.3.3
+	github.com/ElrondNetwork/elrond-vm-util v0.3.4
 	github.com/gin-gonic/gin v1.6.3
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pelletier/go-toml v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/ElrondNetwork/elrond-go-logger v1.0.2 h1:X//QtN5WEPe6yrOL2fgb3EI5IDDA
 github.com/ElrondNetwork/elrond-go-logger v1.0.2/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-vm-common v0.1.21 h1:GosUg0kc9mV9TpEqlsQKkQOikhR6YBWZP0PSHuRLKpQ=
 github.com/ElrondNetwork/elrond-vm-common v0.1.21/go.mod h1:ZakxPST/Wt8umnRtA9gobcy3Dw2bywxwkC54P5VhO9g=
-github.com/ElrondNetwork/elrond-vm-util v0.3.3 h1:vU4ggnKKweE/SERA46LjncRB9UEAt0wu9Z4BnqiT0JE=
-github.com/ElrondNetwork/elrond-vm-util v0.3.3/go.mod h1:lCXk+AyNVXLet06PzCMBQb/iEWTSxGIoSXOTb6GeWjA=
+github.com/ElrondNetwork/elrond-vm-util v0.3.4 h1:mNrqw9wu5gd2dhsyOW+ioJP7Qu++69T8PgMCrSXrbS8=
+github.com/ElrondNetwork/elrond-vm-util v0.3.4/go.mod h1:lCXk+AyNVXLet06PzCMBQb/iEWTSxGIoSXOTb6GeWjA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/integrationTests/json/vm_test.go
+++ b/integrationTests/json/vm_test.go
@@ -207,20 +207,20 @@ func TestTimelocks(t *testing.T) {
 	}
 }
 
-func TestPromises(t *testing.T) {
-	executor, err := am.NewArwenTestExecutor()
-	require.Nil(t, err)
-	runner := mc.NewScenarioRunner(
-		executor,
-		mc.NewDefaultFileResolver(),
-	)
-	err = runner.RunAllJSONScenariosInDirectory(
-		getTestRoot(),
-		"promises",
-		".scen.json",
-		[]string{})
+// func TestPromises(t *testing.T) {
+// 	executor, err := am.NewArwenTestExecutor()
+// 	require.Nil(t, err)
+// 	runner := mc.NewScenarioRunner(
+// 		executor,
+// 		mc.NewDefaultFileResolver(),
+// 	)
+// 	err = runner.RunAllJSONScenariosInDirectory(
+// 		getTestRoot(),
+// 		"promises",
+// 		".scen.json",
+// 		[]string{})
 
-	if err != nil {
-		t.Error(err)
-	}
-}
+// 	if err != nil {
+// 		t.Error(err)
+// 	}
+// }


### PR DESCRIPTION
This PR disables the API functions `createAsyncCall()` and `setAsyncContextCallback()`, which will be re-enabled after further development.

The corresponding tests have been disabled as well.