### PR TITLE
Fix access to the getOriginalTxHash() API method

### DIFF
--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -265,6 +265,11 @@ func ElrondEIImports() (*wasmer.Imports, error) {
 		return nil, err
 	}
 
+	imports, err = imports.Append("getOriginalTxHash", getOriginalTxHash, C.getOriginalTxHash)
+	if err != nil {
+		return nil, err
+	}
+
 	imports, err = imports.Append("getGasLeft", getGasLeft, C.getGasLeft)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds the API method `getOriginalTxHash()` to Wasmer's `Imports`.