### PR TITLE
Improve instance context management

### DIFF
--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -289,14 +289,6 @@ func (context *runtimeContext) SetReadOnly(readOnly bool) {
 	context.readOnly = readOnly
 }
 
-func (context *runtimeContext) SetInstanceContext(instCtx *wasmer.InstanceContext) {
-	// TODO remove this method when the vmContextMap is removed
-}
-
-func (context *runtimeContext) GetInstanceContext() *wasmer.InstanceContext {
-	return &context.instance.InstanceCtx
-}
-
 func (context *runtimeContext) GetInstanceExports() wasmer.ExportsMap {
 	return context.instance.Exports
 }

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -11,14 +11,13 @@ import (
 var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
 type runtimeContext struct {
-	host            arwen.VMHost
-	instance        *wasmer.Instance
-	instanceContext *wasmer.InstanceContext
-	vmInput         *vmcommon.VMInput
-	scAddress       []byte
-	callFunction    string
-	vmType          []byte
-	readOnly        bool
+	host         arwen.VMHost
+	instance     *wasmer.Instance
+	vmInput      *vmcommon.VMInput
+	scAddress    []byte
+	callFunction string
+	vmType       []byte
+	readOnly     bool
 
 	stateStack    []*runtimeContext
 	instanceStack []*wasmer.Instance
@@ -291,11 +290,11 @@ func (context *runtimeContext) SetReadOnly(readOnly bool) {
 }
 
 func (context *runtimeContext) SetInstanceContext(instCtx *wasmer.InstanceContext) {
-	context.instanceContext = instCtx
+	// TODO remove this method when the vmContextMap is removed
 }
 
 func (context *runtimeContext) GetInstanceContext() *wasmer.InstanceContext {
-	return context.instanceContext
+	return &context.instance.InstanceCtx
 }
 
 func (context *runtimeContext) GetInstanceExports() wasmer.ExportsMap {
@@ -380,7 +379,7 @@ func (context *runtimeContext) MemLoad(offset int32, length int32) ([]byte, erro
 		return []byte{}, nil
 	}
 
-	memory := context.instanceContext.Memory()
+	memory := context.instance.InstanceCtx.Memory()
 	memoryView := memory.Data()
 	memoryLength := memory.Length()
 	requestedEnd := uint32(offset + length)
@@ -412,7 +411,7 @@ func (context *runtimeContext) MemStore(offset int32, data []byte) error {
 		return nil
 	}
 
-	memory := context.instanceContext.Memory()
+	memory := context.instance.InstanceCtx.Memory()
 	memoryView := memory.Data()
 	memoryLength := memory.Length()
 	requestedEnd := uint32(offset + dataLength)

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -2,7 +2,6 @@ package contexts
 
 import (
 	"fmt"
-	"unsafe"
 
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
 	"github.com/ElrondNetwork/arwen-wasm-vm/wasmer"
@@ -12,16 +11,14 @@ import (
 var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
 type runtimeContext struct {
-	host     arwen.VMHost
-	instance *wasmer.Instance
-	// Temporarily holding these pointers are supposed to circumvent an undesired deallocation performed by Go's GC
-	instanceContextDataPointers []*int
-	instanceContext             *wasmer.InstanceContext
-	vmInput                     *vmcommon.VMInput
-	scAddress                   []byte
-	callFunction                string
-	vmType                      []byte
-	readOnly                    bool
+	host            arwen.VMHost
+	instance        *wasmer.Instance
+	instanceContext *wasmer.InstanceContext
+	vmInput         *vmcommon.VMInput
+	scAddress       []byte
+	callFunction    string
+	vmType          []byte
+	readOnly        bool
 
 	stateStack    []*runtimeContext
 	instanceStack []*wasmer.Instance
@@ -40,12 +37,11 @@ func NewRuntimeContext(host arwen.VMHost, vmType []byte) (*runtimeContext, error
 	protocolBuiltinFunctions := host.GetProtocolBuiltinFunctions()
 
 	context := &runtimeContext{
-		host:                        host,
-		instanceContextDataPointers: make([]*int, 0),
-		vmType:                      vmType,
-		stateStack:                  make([]*runtimeContext, 0),
-		instanceStack:               make([]*wasmer.Instance, 0),
-		validator:                   NewWASMValidator(scAPINames, protocolBuiltinFunctions),
+		host:          host,
+		vmType:        vmType,
+		stateStack:    make([]*runtimeContext, 0),
+		instanceStack: make([]*wasmer.Instance, 0),
+		validator:     NewWASMValidator(scAPINames, protocolBuiltinFunctions),
 	}
 
 	context.InitState()
@@ -54,13 +50,12 @@ func NewRuntimeContext(host arwen.VMHost, vmType []byte) (*runtimeContext, error
 }
 
 func (context *runtimeContext) InitState() {
-	context.instanceContextDataPointers = make([]*int, 0)
 	context.vmInput = &vmcommon.VMInput{}
 	context.scAddress = make([]byte, 0)
 	context.callFunction = ""
 	context.readOnly = false
 	context.asyncCallInfo = nil
-	context.asyncContextInfo = &arwen.AsyncContextInfo {
+	context.asyncContextInfo = &arwen.AsyncContextInfo{
 		AsyncContextMap: make(map[string]*arwen.AsyncContext),
 	}
 }
@@ -83,6 +78,16 @@ func (context *runtimeContext) StartWasmerInstance(contract []byte, gasLimit uin
 	}
 
 	context.instance = newInstance
+
+	idContext := arwen.AddHostContext(context.host)
+	context.instance.SetContextData(idContext)
+
+	err = context.VerifyContractCode()
+	if err != nil {
+		context.instance = nil
+		return err
+	}
+
 	context.SetRuntimeBreakpointValue(arwen.BreakpointNone)
 	return nil
 }
@@ -96,8 +101,8 @@ func (context *runtimeContext) InitStateFromContractCallInput(input *vmcommon.Co
 	context.scAddress = input.RecipientAddr
 	context.callFunction = input.Function
 	// Reset async map for initial state
-	context.asyncContextInfo = &arwen.AsyncContextInfo {
-		CallerAddr: input.CallerAddr,
+	context.asyncContextInfo = &arwen.AsyncContextInfo{
+		CallerAddr:      input.CallerAddr,
 		AsyncContextMap: make(map[string]*arwen.AsyncContext),
 	}
 }
@@ -150,7 +155,7 @@ func (context *runtimeContext) PopInstance() {
 	prevInstance := context.instanceStack[instanceStackLen-1]
 	context.instanceStack = context.instanceStack[:instanceStackLen-1]
 
-	context.CleanInstance()
+	context.CleanWasmerInstance()
 	context.instance = prevInstance
 }
 
@@ -285,11 +290,6 @@ func (context *runtimeContext) SetReadOnly(readOnly bool) {
 	context.readOnly = readOnly
 }
 
-func (context *runtimeContext) SetInstanceContextID(id int) {
-	context.instanceContextDataPointers = append(context.instanceContextDataPointers, &id)
-	context.instance.SetContextData(unsafe.Pointer(&id))
-}
-
 func (context *runtimeContext) SetInstanceContext(instCtx *wasmer.InstanceContext) {
 	context.instanceContext = instCtx
 }
@@ -302,10 +302,12 @@ func (context *runtimeContext) GetInstanceExports() wasmer.ExportsMap {
 	return context.instance.Exports
 }
 
-func (context *runtimeContext) CleanInstance() {
+func (context *runtimeContext) CleanWasmerInstance() {
 	if context.instance == nil {
 		return
 	}
+
+	arwen.RemoveHostContext(*context.instance.Data)
 	context.instance.Clean()
 	context.instance = nil
 }

--- a/arwen/contexts/runtime_test.go
+++ b/arwen/contexts/runtime_test.go
@@ -368,6 +368,7 @@ func TestRuntimeContext_MemLoadStoreOk(t *testing.T) {
 
 	pageSize := uint32(65536)
 	require.Equal(t, 2*pageSize, memory.Length())
+
 	memContents = []byte("test data")
 	err = runtimeContext.MemStore(10, memContents)
 	require.Nil(t, err)
@@ -510,4 +511,67 @@ func TestRuntimeContext_MemStoreCases(t *testing.T) {
 	memContents, err = runtimeContext.MemLoad(offset, 17)
 	require.Nil(t, err)
 	require.Equal(t, []byte("this is something"), memContents)
+}
+
+func TestRuntimeContext_MemLoadStoreVsInstanceStack(t *testing.T) {
+	imports := InitializeWasmer()
+
+	host := &mock.VmHostMock{}
+	host.SCAPIMethods = imports
+
+	vmType := []byte("type")
+	runtimeContext, _ := NewRuntimeContext(host, vmType)
+	runtimeContext.SetMaxInstanceCount(2)
+
+	gasLimit := uint64(100000000)
+	path := "./../../test/contracts/counter/output/counter.wasm"
+	contractCode := arwen.GetSCCode(path)
+	err := runtimeContext.StartWasmerInstance(contractCode, gasLimit)
+	require.Nil(t, err)
+
+	// Write "test data1" to the WASM memory of the current instance
+	memContents := []byte("test data1")
+	err = runtimeContext.MemStore(10, memContents)
+	require.Nil(t, err)
+
+	memContents, err = runtimeContext.MemLoad(10, 10)
+	require.Nil(t, err)
+	require.Equal(t, []byte("test data1"), memContents)
+
+	// Push the current instance down the instance stack
+	runtimeContext.PushInstance()
+	require.Equal(t, 1, len(runtimeContext.instanceStack))
+
+	// Create a new Wasmer instance
+	contractCode = arwen.GetSCCode(path)
+	err = runtimeContext.StartWasmerInstance(contractCode, gasLimit)
+	require.Nil(t, err)
+
+	// Write "test data2" to the WASM memory of the new instance
+	memContents = []byte("test data2")
+	err = runtimeContext.MemStore(10, memContents)
+	require.Nil(t, err)
+
+	memContents, err = runtimeContext.MemLoad(10, 10)
+	require.Nil(t, err)
+	require.Equal(t, []byte("test data2"), memContents)
+
+	// Pop the initial instance from the stack, making it the 'current instance'
+	runtimeContext.PopInstance()
+	require.Equal(t, 0, len(runtimeContext.instanceStack))
+
+	// Check whether the previously-written string "test data1" is still in the
+	// memory of the initial instance
+	memContents, err = runtimeContext.MemLoad(10, 10)
+	require.Nil(t, err)
+	require.Equal(t, []byte("test data1"), memContents)
+
+	// Write "test data3" to the WASM memory of the initial instance (now current)
+	memContents = []byte("test data3")
+	err = runtimeContext.MemStore(10, memContents)
+	require.Nil(t, err)
+
+	memContents, err = runtimeContext.MemLoad(10, 10)
+	require.Nil(t, err)
+	require.Equal(t, []byte("test data3"), memContents)
 }

--- a/arwen/contexts/runtime_test.go
+++ b/arwen/contexts/runtime_test.go
@@ -361,7 +361,6 @@ func TestRuntimeContext_MemLoadStoreOk(t *testing.T) {
 	require.Nil(t, err)
 
 	memory := runtimeContext.instance.Memory
-	runtimeContext.instanceContext = wasmer.NewInstanceContext(nil, *memory)
 
 	memContents, err := runtimeContext.MemLoad(10, 10)
 	require.Nil(t, err)
@@ -396,7 +395,6 @@ func TestRuntimeContext_MemLoadCases(t *testing.T) {
 	require.Nil(t, err)
 
 	memory := runtimeContext.instance.Memory
-	runtimeContext.instanceContext = wasmer.NewInstanceContext(nil, *memory)
 
 	var offset int32
 	var length int32
@@ -465,7 +463,6 @@ func TestRuntimeContext_MemStoreCases(t *testing.T) {
 	pageSize := uint32(65536)
 	memory := runtimeContext.instance.Memory
 	require.Equal(t, 2*pageSize, memory.Length())
-	runtimeContext.instanceContext = wasmer.NewInstanceContext(nil, *memory)
 
 	// Bad lower bounds
 	memContents := []byte("test data")

--- a/arwen/contexts/runtime_test.go
+++ b/arwen/contexts/runtime_test.go
@@ -279,7 +279,7 @@ func TestRuntimeContext_Instance(t *testing.T) {
 	initFunc := runtimeContext.GetInitFunction()
 	require.NotNil(t, initFunc)
 
-	runtimeContext.CleanInstance()
+	runtimeContext.CleanWasmerInstance()
 	require.Nil(t, runtimeContext.instance)
 }
 

--- a/arwen/host.go
+++ b/arwen/host.go
@@ -44,10 +44,7 @@ func GetVmContext(context unsafe.Pointer) VMHost {
 	instCtx := wasmer.IntoInstanceContext(context)
 	var idx = *(*int)(instCtx.Data())
 
-	ctx := vmContextMap[uint8(idx)]
-	ctx.Runtime().SetInstanceContext(&instCtx)
-
-	return ctx
+	return vmContextMap[uint8(idx)]
 }
 
 func GetBlockchainContext(context unsafe.Pointer) BlockchainContext {

--- a/arwen/host/arwen.go
+++ b/arwen/host/arwen.go
@@ -196,7 +196,7 @@ func (host *vmHost) ClearContextStateStack() {
 }
 
 func (host *vmHost) Clean() {
-	host.runtimeContext.CleanInstance()
+	host.runtimeContext.CleanWasmerInstance()
 	arwen.RemoveAllHostContexts()
 }
 

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -100,8 +100,6 @@ type RuntimeContext interface {
 	CleanWasmerInstance()
 	SetMaxInstanceCount(uint64)
 	VerifyContractCode() error
-	SetInstanceContext(instCtx *wasmer.InstanceContext)
-	GetInstanceContext() *wasmer.InstanceContext
 	GetInstanceExports() wasmer.ExportsMap
 	GetInitFunction() wasmer.ExportedFunctionCallback
 	GetFunctionToCall() (wasmer.ExportedFunctionCallback, error)

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -97,6 +97,7 @@ type RuntimeContext interface {
 	ReadOnly() bool
 	SetReadOnly(readOnly bool)
 	StartWasmerInstance(contract []byte, gasLimit uint64) error
+	CleanWasmerInstance()
 	SetMaxInstanceCount(uint64)
 	VerifyContractCode() error
 	SetInstanceContext(instCtx *wasmer.InstanceContext)
@@ -108,8 +109,6 @@ type RuntimeContext interface {
 	SetPointsUsed(gasPoints uint64)
 	MemStore(offset int32, data []byte) error
 	MemLoad(offset int32, length int32) ([]byte, error)
-	CleanInstance()
-	SetInstanceContextID(id int)
 	ElrondAPIErrorShouldFailExecution() bool
 	CryptoAPIErrorShouldFailExecution() bool
 	BigIntAPIErrorShouldFailExecution() bool

--- a/mock/runtimeContextMock.go
+++ b/mock/runtimeContextMock.go
@@ -165,7 +165,7 @@ func (r *RuntimeContextMock) GetInstanceExports() wasmer.ExportsMap {
 	return nil
 }
 
-func (r *RuntimeContextMock) CleanInstance() {
+func (r *RuntimeContextMock) CleanWasmerInstance() {
 }
 
 func (r *RuntimeContextMock) GetFunctionToCall() (wasmer.ExportedFunctionCallback, error) {

--- a/mock/runtimeContextMock.go
+++ b/mock/runtimeContextMock.go
@@ -150,17 +150,6 @@ func (r *RuntimeContextMock) SetReadOnly(readOnly bool) {
 	r.ReadOnlyFlag = readOnly
 }
 
-func (r *RuntimeContextMock) SetInstanceContextID(id int) {
-	r.InstanceCtxID = id
-}
-
-func (r *RuntimeContextMock) SetInstanceContext(instCtx *wasmer.InstanceContext) {
-}
-
-func (r *RuntimeContextMock) GetInstanceContext() *wasmer.InstanceContext {
-	return nil
-}
-
 func (r *RuntimeContextMock) GetInstanceExports() wasmer.ExportsMap {
 	return nil
 }

--- a/wasmer/bridge.go
+++ b/wasmer/bridge.go
@@ -207,6 +207,12 @@ func cWasmerInstanceCall(
 	))
 }
 
+func cWasmerInstanceContextGet(instance *cWasmerInstanceT) *cWasmerInstanceContextT {
+	return (*cWasmerInstanceContextT)(C.wasmer_instance_context_get(
+		(*C.wasmer_instance_t)(instance),
+	))
+}
+
 func cWasmerInstanceContextDataGet(instanceContext *cWasmerInstanceContextT) unsafe.Pointer {
 	return unsafe.Pointer(C.wasmer_instance_context_data_get(
 		(*C.wasmer_instance_context_t)(instanceContext),

--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -201,7 +201,6 @@ func IntoInstanceContext(instanceContext unsafe.Pointer) InstanceContext {
 
 func IntoInstanceContextDirect(instanceContext *cWasmerInstanceContextT) InstanceContext {
 	memory := newMemory(cWasmerInstanceContextMemory(instanceContext))
-
 	return InstanceContext{instanceContext, memory}
 }
 

--- a/wasmer/import.go
+++ b/wasmer/import.go
@@ -199,6 +199,12 @@ func IntoInstanceContext(instanceContext unsafe.Pointer) InstanceContext {
 	return InstanceContext{context, memory}
 }
 
+func IntoInstanceContextDirect(instanceContext *cWasmerInstanceContextT) InstanceContext {
+	memory := newMemory(cWasmerInstanceContextMemory(instanceContext))
+
+	return InstanceContext{instanceContext, memory}
+}
+
 // Memory returns the current instance memory.
 func (instanceContext *InstanceContext) Memory() *Memory {
 	return &instanceContext.memory

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -83,7 +83,8 @@ type Instance struct {
 	// The exported memory of a WebAssembly instance.
 	Memory *Memory
 
-	Data unsafe.Pointer
+	Data        *int
+	DataPointer unsafe.Pointer
 }
 
 type CompilationOptions struct {
@@ -188,9 +189,10 @@ func (instance *Instance) HasMemory() bool {
 // context can hold a pointer to any kind of data. It is important to
 // understand that this data is shared by all imported function, it's
 // global to the instance.
-func (instance *Instance) SetContextData(data unsafe.Pointer) {
-	cWasmerInstanceContextDataSet(instance.instance, data)
-	instance.Data = data
+func (instance *Instance) SetContextData(data int) {
+	instance.Data = &data
+	instance.DataPointer = unsafe.Pointer(instance.Data)
+	cWasmerInstanceContextDataSet(instance.instance, instance.DataPointer)
 }
 
 func (instance *Instance) Clean() {

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -85,6 +85,8 @@ type Instance struct {
 
 	Data        *int
 	DataPointer unsafe.Pointer
+
+	InstanceCtx InstanceContext
 }
 
 type CompilationOptions struct {
@@ -149,6 +151,10 @@ func NewInstanceWithOptions(
 	}
 
 	instance, err := newInstance(c_instance)
+	if instance.Memory != nil {
+		c_instance_context := cWasmerInstanceContextGet(c_instance)
+		instance.InstanceCtx = IntoInstanceContextDirect(c_instance_context)
+	}
 	return instance, err
 }
 


### PR DESCRIPTION
This PR adds the following changes to the `RuntimeContext` and to the methods in `execution.go`:

* Individual Wasmer instances now contain their own `InstanceContext` object, which obviates the need for maintaining the references separately. This fixes a bug in `elrondei.go`, which caused a panic if the WASM memory was accessed _after_ pushing / popping the instance stack of the `RuntimeContext` (this exact issue was happening in the `createContract()` API method). By putting the `InstanceContext` pointer inside the Wasmer instance, the `InstanceContext` objects are automatically kept on a stack (since Wasmer instances are already stacked).
* Method `RuntimeContext.SetInstanceContextID()` was removed due to the change described above.
* Putting `InstanceContext` objects inside Wasmer instances is the first and most important step for decoupling the `RuntimeContext` from the `vmContextMap`, but removing the `vmContextMap` will come later.
* All calls to `arwen.AddHostContext()` and `arwen.RemoveHostContext()` have been deleted from `execution.go` and moved into the `RuntimeContext`. After the removal of `vmContextMap`, they will be removed as well, eventually.