### PR TITLE
Wrap VMOutput in a JSON-friendly structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 arwen:
 	go build -o ./cmd/arwen/arwen ./cmd/arwen
 	cp ./cmd/arwen/arwen ./ipc/tests
+	cp ./cmd/arwen/arwen ${ARWEN_PATH}
 
 arwendebug:
 ifndef ARWENDEBUG_PATH

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ElrondNetwork/elrond-go-logger v1.0.2
 	github.com/ElrondNetwork/elrond-vm-common v0.1.23
 	github.com/ElrondNetwork/elrond-vm-util v0.3.5
+	github.com/davecgh/go-spew v1.1.1
 	github.com/gin-gonic/gin v1.6.3
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pelletier/go-toml v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ElrondNetwork/elrond-go-logger v1.0.2
 	github.com/ElrondNetwork/elrond-vm-common v0.1.23
 	github.com/ElrondNetwork/elrond-vm-util v0.3.5
-	github.com/davecgh/go-spew v1.1.1
 	github.com/gin-gonic/gin v1.6.3
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pelletier/go-toml v1.6.0

--- a/ipc/common/messages.go
+++ b/ipc/common/messages.go
@@ -53,10 +53,10 @@ const (
 	BlockchainGetUserAccountResponse
 	BlockchainGetShardOfAddressRequest
 	BlockchainGetShardOfAddressResponse
-	BlockchainIsSmartContractRequest
-	BlockchainIsSmartContractResponse
 	BlockchainIsPayableRequest
 	BlockchainIsPayableResponse
+	BlockchainIsSmartContractRequest
+	BlockchainIsSmartContractResponse
 	DiagnoseWaitRequest
 	DiagnoseWaitResponse
 	UndefinedRequestOrResponse

--- a/ipc/common/messagesBlockchain.go
+++ b/ipc/common/messagesBlockchain.go
@@ -469,6 +469,7 @@ func NewMessageBlockchainGetAllStateRequest(address []byte) *MessageBlockchainGe
 // MessageBlockchainGetAllStateResponse represents a response message
 type MessageBlockchainGetAllStateResponse struct {
 	Message
+	// TODO: Make sure to change "map[string][]byte" to a JSON-serializable friendly structure when "GetAllState()" will be used
 	AllState map[string][]byte
 }
 

--- a/ipc/common/messagesContracts.go
+++ b/ipc/common/messagesContracts.go
@@ -35,14 +35,14 @@ func NewMessageContractCallRequest(input *vmcommon.ContractCallInput) *MessageCo
 // MessageContractResponse is a contract response message (from Arwen)
 type MessageContractResponse struct {
 	Message
-	VMOutput *vmcommon.VMOutput
+	SerializableVMOutput *SerializableVMOutput
 }
 
 // NewMessageContractResponse creates a message
 func NewMessageContractResponse(vmOutput *vmcommon.VMOutput, err error) *MessageContractResponse {
 	message := &MessageContractResponse{}
 	message.Kind = ContractResponse
-	message.VMOutput = vmOutput
+	message.SerializableVMOutput = NewSerializableVMOutput(vmOutput)
 	message.SetError(err)
 	return message
 }

--- a/ipc/common/messages_test.go
+++ b/ipc/common/messages_test.go
@@ -1,13 +1,11 @@
 package common
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/ElrondNetwork/arwen-wasm-vm/ipc/marshaling"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,7 +47,7 @@ func TestMessageContractResponse_CanWrapNilVMOutput(t *testing.T) {
 	expectedEmptyVMOutput := vmcommon.VMOutput{OutputAccounts: make(map[string]*vmcommon.OutputAccount)}
 	actualVMOutput := *message.SerializableVMOutput.ConvertToVMOutput()
 
-	require.Equal(t, spew.Sdump(expectedEmptyVMOutput), spew.Sdump(actualVMOutput))
+	require.True(t, reflect.DeepEqual(expectedEmptyVMOutput, actualVMOutput))
 	requireSerializationConsistency(t, message, &MessageContractResponse{})
 }
 
@@ -65,8 +63,6 @@ func TestMessageBlockchainGetAllStateResponse_IsConsistentlySerializable(t *test
 }
 
 func requireSerializationConsistency(t *testing.T, message interface{}, intoMessage interface{}) {
-	spew.Config.SortKeys = true
-	spew.Config.Indent = "\t"
 	marshalizer := marshaling.CreateMarshalizer(marshaling.JSON)
 
 	serialized, err := marshalizer.Marshal(message)
@@ -76,10 +72,6 @@ func requireSerializationConsistency(t *testing.T, message interface{}, intoMess
 
 	areEqual := reflect.DeepEqual(message, intoMessage)
 	if !areEqual {
-		fmt.Println("### Original message ###")
-		spew.Dump(message)
-		fmt.Println("### Into message ###")
-		spew.Dump(intoMessage)
 		require.FailNow(t, "Serialization is not consistent.")
 	}
 }

--- a/ipc/common/messages_test.go
+++ b/ipc/common/messages_test.go
@@ -1,0 +1,85 @@
+package common
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/ElrondNetwork/arwen-wasm-vm/ipc/marshaling"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageContractResponse_IsConsistentlySerializable(t *testing.T) {
+	vmOutput := &vmcommon.VMOutput{OutputAccounts: make(map[string]*vmcommon.OutputAccount)}
+	vmOutput.OutputAccounts["alice"] = &vmcommon.OutputAccount{StorageUpdates: make(map[string]*vmcommon.StorageUpdate)}
+	vmOutput.OutputAccounts["alice"].StorageUpdates["foo"] = &vmcommon.StorageUpdate{}
+	vmOutput.OutputAccounts["alice"].StorageUpdates["bar"] = &vmcommon.StorageUpdate{}
+	message := NewMessageContractResponse(vmOutput, nil)
+	requireSerializationConsistency(t, message, &MessageContractResponse{})
+
+	// Non text as output account keys
+	vmOutput = &vmcommon.VMOutput{OutputAccounts: make(map[string]*vmcommon.OutputAccount)}
+	vmOutput.OutputAccounts[string([]byte{0})] = &vmcommon.OutputAccount{StorageUpdates: make(map[string]*vmcommon.StorageUpdate)}
+	vmOutput.OutputAccounts[string([]byte{0})].StorageUpdates["foo"] = &vmcommon.StorageUpdate{}
+	vmOutput.OutputAccounts[string([]byte{0})].StorageUpdates["bar"] = &vmcommon.StorageUpdate{}
+	message = NewMessageContractResponse(vmOutput, nil)
+	requireSerializationConsistency(t, message, &MessageContractResponse{})
+
+	// Non UTF-8 as output account keys
+	vmOutput = &vmcommon.VMOutput{OutputAccounts: make(map[string]*vmcommon.OutputAccount)}
+	vmOutput.OutputAccounts[string([]byte{128})] = &vmcommon.OutputAccount{StorageUpdates: make(map[string]*vmcommon.StorageUpdate)}
+	vmOutput.OutputAccounts[string([]byte{128})].StorageUpdates["foo"] = &vmcommon.StorageUpdate{}
+	vmOutput.OutputAccounts[string([]byte{128})].StorageUpdates["bar"] = &vmcommon.StorageUpdate{}
+	message = NewMessageContractResponse(vmOutput, nil)
+	requireSerializationConsistency(t, message, &MessageContractResponse{})
+
+	// Non UTF-8 as storage update keys
+	vmOutput = &vmcommon.VMOutput{OutputAccounts: make(map[string]*vmcommon.OutputAccount)}
+	vmOutput.OutputAccounts["alice"] = &vmcommon.OutputAccount{StorageUpdates: make(map[string]*vmcommon.StorageUpdate)}
+	vmOutput.OutputAccounts["alice"].StorageUpdates[string([]byte{128})] = &vmcommon.StorageUpdate{}
+	vmOutput.OutputAccounts["alice"].StorageUpdates[string([]byte{129})] = &vmcommon.StorageUpdate{}
+	message = NewMessageContractResponse(vmOutput, nil)
+	requireSerializationConsistency(t, message, &MessageContractResponse{})
+}
+
+func TestMessageContractResponse_CanWrapNilVMOutput(t *testing.T) {
+	message := NewMessageContractResponse(nil, nil)
+	expectedEmptyVMOutput := vmcommon.VMOutput{OutputAccounts: make(map[string]*vmcommon.OutputAccount)}
+	actualVMOutput := *message.SerializableVMOutput.ConvertToVMOutput()
+
+	require.Equal(t, spew.Sdump(expectedEmptyVMOutput), spew.Sdump(actualVMOutput))
+	requireSerializationConsistency(t, message, &MessageContractResponse{})
+}
+
+func TestMessageBlockchainGetAllStateResponse_IsConsistentlySerializable(t *testing.T) {
+	t.Skip("GetAllState isn't used at this moment")
+
+	allState := make(map[string][]byte)
+	allState["foo"] = []byte{0}
+	allState[string([]byte{0})] = []byte{0}
+	allState[string([]byte{128})] = []byte{0}
+	message := NewMessageBlockchainGetAllStateResponse(allState, nil)
+	requireSerializationConsistency(t, message, &MessageBlockchainGetAllStateResponse{})
+}
+
+func requireSerializationConsistency(t *testing.T, message interface{}, intoMessage interface{}) {
+	spew.Config.SortKeys = true
+	spew.Config.Indent = "\t"
+	marshalizer := marshaling.CreateMarshalizer(marshaling.JSON)
+
+	serialized, err := marshalizer.Marshal(message)
+	require.Nil(t, err)
+	err = marshalizer.Unmarshal(intoMessage, serialized)
+	require.Nil(t, err)
+
+	areEqual := reflect.DeepEqual(message, intoMessage)
+	if !areEqual {
+		fmt.Println("### Original message ###")
+		spew.Dump(message)
+		fmt.Println("### Into message ###")
+		spew.Dump(intoMessage)
+		require.FailNow(t, "Serialization is not consistent.")
+	}
+}

--- a/ipc/common/serializableVMOutput.go
+++ b/ipc/common/serializableVMOutput.go
@@ -1,0 +1,118 @@
+package common
+
+import (
+	"math/big"
+
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+)
+
+type SerializableVMOutput struct {
+	ReturnData              [][]byte
+	ReturnCode              vmcommon.ReturnCode
+	ReturnMessage           string
+	GasRemaining            uint64
+	GasRefund               *big.Int
+	CorrectedOutputAccounts []*SerializableOutputAccount
+	DeletedAccounts         [][]byte
+	TouchedAccounts         [][]byte
+	Logs                    []*vmcommon.LogEntry
+}
+
+func NewSerializableVMOutput(vmOutput *vmcommon.VMOutput) *SerializableVMOutput {
+	if vmOutput == nil {
+		return &SerializableVMOutput{}
+	}
+
+	o := &SerializableVMOutput{
+		ReturnData:              vmOutput.ReturnData,
+		ReturnCode:              vmOutput.ReturnCode,
+		ReturnMessage:           vmOutput.ReturnMessage,
+		GasRemaining:            vmOutput.GasRemaining,
+		GasRefund:               vmOutput.GasRefund,
+		CorrectedOutputAccounts: make([]*SerializableOutputAccount, 0, len(vmOutput.OutputAccounts)),
+		DeletedAccounts:         vmOutput.DeletedAccounts,
+		TouchedAccounts:         vmOutput.TouchedAccounts,
+		Logs:                    vmOutput.Logs,
+	}
+
+	for _, account := range vmOutput.OutputAccounts {
+		o.CorrectedOutputAccounts = append(o.CorrectedOutputAccounts, NewSerializableOutputAccount(account))
+	}
+
+	return o
+}
+
+func (o *SerializableVMOutput) ConvertToVMOutput() *vmcommon.VMOutput {
+	accountsMap := make(map[string]*vmcommon.OutputAccount)
+
+	for _, item := range o.CorrectedOutputAccounts {
+		accountsMap[string(item.Address)] = item.ConvertToOutputAccount()
+	}
+
+	return &vmcommon.VMOutput{
+		ReturnData:      o.ReturnData,
+		ReturnCode:      o.ReturnCode,
+		ReturnMessage:   o.ReturnMessage,
+		GasRemaining:    o.GasRemaining,
+		GasRefund:       o.GasRefund,
+		OutputAccounts:  accountsMap,
+		DeletedAccounts: o.DeletedAccounts,
+		TouchedAccounts: o.TouchedAccounts,
+		Logs:            o.Logs,
+	}
+}
+
+type SerializableOutputAccount struct {
+	Address        []byte
+	Nonce          uint64
+	Balance        *big.Int
+	BalanceDelta   *big.Int
+	StorageUpdates []*vmcommon.StorageUpdate
+	Code           []byte
+	CodeMetadata   []byte
+	Data           []byte
+	GasLimit       uint64
+	CallType       vmcommon.CallType
+}
+
+func NewSerializableOutputAccount(account *vmcommon.OutputAccount) *SerializableOutputAccount {
+	a := &SerializableOutputAccount{
+		Address:        account.Address,
+		Nonce:          account.Nonce,
+		Balance:        account.Balance,
+		BalanceDelta:   account.BalanceDelta,
+		StorageUpdates: make([]*vmcommon.StorageUpdate, 0, len(account.StorageUpdates)),
+		Code:           account.Code,
+		CodeMetadata:   account.CodeMetadata,
+		Data:           account.Data,
+		GasLimit:       account.GasLimit,
+		CallType:       account.CallType,
+	}
+
+	for _, storageUpdate := range account.StorageUpdates {
+		a.StorageUpdates = append(a.StorageUpdates, storageUpdate)
+	}
+
+	return a
+}
+
+func (a *SerializableOutputAccount) ConvertToOutputAccount() *vmcommon.OutputAccount {
+	updatesMap := make(map[string]*vmcommon.StorageUpdate)
+
+	for _, item := range a.StorageUpdates {
+		updatesMap[string(item.Offset)] = item
+	}
+
+	return &vmcommon.OutputAccount{
+		Address:        a.Address,
+		Nonce:          a.Nonce,
+		Balance:        a.Balance,
+		BalanceDelta:   a.BalanceDelta,
+		StorageUpdates: updatesMap,
+		Code:           a.Code,
+		CodeMetadata:   a.CodeMetadata,
+		Data:           a.Data,
+		GasLimit:       a.GasLimit,
+		CallType:       a.CallType,
+	}
+}

--- a/ipc/nodepart/arwenDriver.go
+++ b/ipc/nodepart/arwenDriver.go
@@ -214,7 +214,7 @@ func (driver *ArwenDriver) RunSmartContractCreate(input *vmcommon.ContractCreate
 	}
 
 	typedResponse := response.(*common.MessageContractResponse)
-	vmOutput, err := typedResponse.VMOutput, response.GetError()
+	vmOutput, err := typedResponse.SerializableVMOutput.ConvertToVMOutput(), response.GetError()
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (driver *ArwenDriver) RunSmartContractCall(input *vmcommon.ContractCallInpu
 	}
 
 	typedResponse := response.(*common.MessageContractResponse)
-	vmOutput, err := typedResponse.VMOutput, response.GetError()
+	vmOutput, err := typedResponse.SerializableVMOutput.ConvertToVMOutput(), response.GetError()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue:

 - `VMOutput` contains nested `map[string]interface{}`, and this leads to have the map keys UTF-8 encoded in the context of JSON serialization (required by Node - Arwen Inter Process Communication).
 - Though, the keys could contain JSON-invalid (non UTF-8) sequences of bytes
 - Such keys were subject to UTF-8 encoding replacements - which could sometimes result in undesired de-duplication of map keys at deserialization time.

Changes:
 - Wrapped `VMOutput` in a JSON-friendly structure
 - Added tests