### PR TITLE
More minor improvements

### DIFF
--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -14,6 +14,7 @@ type outputContext struct {
 	host        arwen.VMHost
 	outputState *vmcommon.VMOutput
 	stateStack  []*vmcommon.VMOutput
+	codeUpdates map[string]struct{}
 }
 
 // NewOutputContext creates a new outputContext
@@ -30,6 +31,7 @@ func NewOutputContext(host arwen.VMHost) (*outputContext, error) {
 
 func (context *outputContext) InitState() {
 	context.outputState = newVMOutput()
+	context.codeUpdates = make(map[string]struct{})
 }
 
 func newVMOutput() *vmcommon.VMOutput {
@@ -122,6 +124,7 @@ func (context *outputContext) GetOutputAccount(address []byte) (*vmcommon.Output
 
 func (context *outputContext) DeleteOutputAccount(address []byte) {
 	delete(context.outputState.OutputAccounts, string(address))
+	delete(context.codeUpdates, string(address))
 }
 
 func (context *outputContext) GetRefund() uint64 {
@@ -220,6 +223,7 @@ func (context *outputContext) AddTxValueToAccount(address []byte, value *big.Int
 // GetVMOutput updates the current VMOutput and returns it
 func (context *outputContext) GetVMOutput() *vmcommon.VMOutput {
 	context.outputState.GasRemaining = context.host.Metering().GasLeft()
+	context.removeNonUpdatedCode(context.outputState)
 	return context.outputState
 }
 
@@ -227,6 +231,9 @@ func (context *outputContext) DeployCode(input arwen.CodeDeployInput) {
 	newSCAccount, _ := context.GetOutputAccount(input.ContractAddress)
 	newSCAccount.Code = input.ContractCode
 	newSCAccount.CodeMetadata = input.ContractCodeMetadata
+
+	var empty struct{}
+	context.codeUpdates[string(input.ContractAddress)] = empty
 }
 
 func (context *outputContext) CreateVMOutputInCaseOfError(err error) *vmcommon.VMOutput {
@@ -251,6 +258,16 @@ func (context *outputContext) CreateVMOutputInCaseOfError(err error) *vmcommon.V
 		GasRefund:     big.NewInt(0),
 		ReturnCode:    returnCode,
 		ReturnMessage: message,
+	}
+}
+
+func (context *outputContext) removeNonUpdatedCode(vmOutput *vmcommon.VMOutput) {
+	for address, account := range vmOutput.OutputAccounts {
+		_, ok := context.codeUpdates[address]
+		if !ok {
+			account.Code = nil
+			account.CodeMetadata = nil
+		}
 	}
 }
 

--- a/arwen/contexts/storage_test.go
+++ b/arwen/contexts/storage_test.go
@@ -92,10 +92,6 @@ func TestStorageContext_SetAddress(t *testing.T) {
 	require.Equal(t, []byte(nil), storageContext.GetStorage(keyA))
 }
 
-func TestStorageContext_StateStack(t *testing.T) {
-	// TODO
-}
-
 func TestStorageContext_GetStorageUpdates(t *testing.T) {
 	t.Parallel()
 
@@ -202,4 +198,12 @@ func TestStorageContext_SetStorage(t *testing.T) {
 	value = []byte("doesn't matter")
 	storageStatus, err = storageContext.SetStorage(key, value)
 	require.Equal(t, arwen.ErrStoreElrondReservedKey, err)
+}
+
+func TestStorageContext_LoadGasStoreGasPerKey(t *testing.T) {
+	// TODO
+}
+
+func TestStorageContext_StoreGasPerKey(t *testing.T) {
+	// TODO
 }

--- a/arwen/elrondapi/bigintOps.go
+++ b/arwen/elrondapi/bigintOps.go
@@ -284,6 +284,9 @@ func bigIntStorageStoreUnsigned(context unsafe.Pointer, keyOffset int32, keyLeng
 	storage := arwen.GetStorageContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntStorageStoreUnsigned
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.BigIntAPIErrorShouldFailExecution()) {
 		return 0
@@ -291,9 +294,6 @@ func bigIntStorageStoreUnsigned(context unsafe.Pointer, keyOffset int32, keyLeng
 
 	value := bigInt.GetOne(source)
 	bytes := value.Bytes()
-
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntStorageStoreUnsigned
-	metering.UseGas(gasToUse)
 
 	storageStatus, err := storage.SetStorage(key, bytes)
 	if arwen.WithFault(err, context, runtime.BigIntAPIErrorShouldFailExecution()) {
@@ -310,6 +310,9 @@ func bigIntStorageLoadUnsigned(context unsafe.Pointer, keyOffset int32, keyLengt
 	storage := arwen.GetStorageContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntStorageLoadUnsigned
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.BigIntAPIErrorShouldFailExecution()) {
 		return 0
@@ -320,10 +323,6 @@ func bigIntStorageLoadUnsigned(context unsafe.Pointer, keyOffset int32, keyLengt
 	value := bigInt.GetOne(destination)
 	value.SetBytes(bytes)
 
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntStorageLoadUnsigned
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
-	metering.UseGas(gasToUse)
-
 	return int32(len(bytes))
 }
 
@@ -333,11 +332,11 @@ func bigIntGetCallValue(context unsafe.Pointer, destination int32) {
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
-	value := bigInt.GetOne(destination)
-	value.Set(runtime.GetVMInput().CallValue)
-
 	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntGetCallValue
 	metering.UseGas(gasToUse)
+
+	value := bigInt.GetOne(destination)
+	value.Set(runtime.GetVMInput().CallValue)
 }
 
 //export bigIntGetExternalBalance
@@ -346,6 +345,9 @@ func bigIntGetExternalBalance(context unsafe.Pointer, addressOffset int32, resul
 	runtime := arwen.GetRuntimeContext(context)
 	blockchain := arwen.GetBlockchainContext(context)
 	metering := arwen.GetMeteringContext(context)
+
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntGetExternalBalance
+	metering.UseGas(gasToUse)
 
 	address, err := runtime.MemLoad(addressOffset, arwen.AddressLen)
 	if arwen.WithFault(err, context, runtime.BigIntAPIErrorShouldFailExecution()) {
@@ -356,9 +358,6 @@ func bigIntGetExternalBalance(context unsafe.Pointer, addressOffset int32, resul
 	value := bigInt.GetOne(result)
 
 	value.SetBytes(balance)
-
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntGetExternalBalance
-	metering.UseGas(gasToUse)
 }
 
 //export bigIntNew
@@ -377,10 +376,10 @@ func bigIntUnsignedByteLength(context unsafe.Pointer, reference int32) int32 {
 	bigInt := arwen.GetBigIntContext(context)
 	metering := arwen.GetMeteringContext(context)
 
-	value := bigInt.GetOne(reference)
-
 	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntUnsignedByteLength
 	metering.UseGas(gasToUse)
+
+	value := bigInt.GetOne(reference)
 
 	bytes := value.Bytes()
 	return int32(len(bytes))
@@ -391,12 +390,12 @@ func bigIntSignedByteLength(context unsafe.Pointer, reference int32) int32 {
 	bigInt := arwen.GetBigIntContext(context)
 	metering := arwen.GetMeteringContext(context)
 
-	value := bigInt.GetOne(reference)
-
 	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntSignedByteLength
 	metering.UseGas(gasToUse)
 
-	bytes := twos.ToBytes(value) // TODO: figure out the correct length without computing the 2's complement
+	value := bigInt.GetOne(reference)
+
+	bytes := twos.ToBytes(value)
 	return int32(len(bytes))
 }
 
@@ -406,6 +405,9 @@ func bigIntGetUnsignedBytes(context unsafe.Pointer, reference int32, byteOffset 
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntGetUnsignedBytes
+	metering.UseGas(gasToUse)
+
 	value := bigInt.GetOne(reference)
 	bytes := value.Bytes()
 
@@ -414,8 +416,7 @@ func bigIntGetUnsignedBytes(context unsafe.Pointer, reference int32, byteOffset 
 		return 0
 	}
 
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntGetUnsignedBytes
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
 	metering.UseGas(gasToUse)
 
 	return int32(len(bytes))
@@ -427,6 +428,9 @@ func bigIntGetSignedBytes(context unsafe.Pointer, reference int32, byteOffset in
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntGetSignedBytes
+	metering.UseGas(gasToUse)
+
 	value := bigInt.GetOne(reference)
 	bytes := twos.ToBytes(value)
 
@@ -435,8 +439,7 @@ func bigIntGetSignedBytes(context unsafe.Pointer, reference int32, byteOffset in
 		return 0
 	}
 
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntGetSignedBytes
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
 	metering.UseGas(gasToUse)
 
 	return int32(len(bytes))
@@ -448,6 +451,9 @@ func bigIntSetUnsignedBytes(context unsafe.Pointer, destination int32, byteOffse
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntSetUnsignedBytes
+	metering.UseGas(gasToUse)
+
 	bytes, err := runtime.MemLoad(byteOffset, byteLength)
 	if arwen.WithFault(err, context, runtime.BigIntAPIErrorShouldFailExecution()) {
 		return
@@ -456,8 +462,7 @@ func bigIntSetUnsignedBytes(context unsafe.Pointer, destination int32, byteOffse
 	value := bigInt.GetOne(destination)
 	value.SetBytes(bytes)
 
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntSetUnsignedBytes
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
 	metering.UseGas(gasToUse)
 }
 
@@ -467,6 +472,9 @@ func bigIntSetSignedBytes(context unsafe.Pointer, destination int32, byteOffset 
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntSetSignedBytes
+	metering.UseGas(gasToUse)
+
 	bytes, err := runtime.MemLoad(byteOffset, byteLength)
 	if arwen.WithFault(err, context, runtime.BigIntAPIErrorShouldFailExecution()) {
 		return
@@ -475,8 +483,7 @@ func bigIntSetSignedBytes(context unsafe.Pointer, destination int32, byteOffset 
 	value := bigInt.GetOne(destination)
 	twos.SetBytes(value, bytes)
 
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntSetSignedBytes
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(bytes))
 	metering.UseGas(gasToUse)
 }
 
@@ -779,12 +786,14 @@ func bigIntFinishUnsigned(context unsafe.Pointer, reference int32) {
 	output := arwen.GetOutputContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntFinishUnsigned
+	metering.UseGas(gasToUse)
+
 	value := bigInt.GetOne(reference)
 	bigIntBytes := value.Bytes()
 	output.Finish(bigIntBytes)
 
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntFinishUnsigned
-	gasToUse += metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(len(value.Bytes()))
+	gasToUse = metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(len(value.Bytes()))
 	metering.UseGas(gasToUse)
 }
 
@@ -794,11 +803,13 @@ func bigIntFinishSigned(context unsafe.Pointer, reference int32) {
 	output := arwen.GetOutputContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntFinishSigned
+	metering.UseGas(gasToUse)
+
 	value := bigInt.GetOne(reference)
 	bigInt2cBytes := twos.ToBytes(value)
 	output.Finish(bigInt2cBytes)
 
-	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntFinishSigned
-	gasToUse += metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(len(bigInt2cBytes))
+	gasToUse = metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(len(bigInt2cBytes))
 	metering.UseGas(gasToUse)
 }

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -720,6 +720,9 @@ func storageStore(context unsafe.Pointer, keyOffset int32, keyLength int32, data
 	storage := arwen.GetStorageContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.StorageStore
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
@@ -729,9 +732,6 @@ func storageStore(context unsafe.Pointer, keyOffset int32, keyLength int32, data
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.StorageStore
-	metering.UseGas(gasToUse)
 
 	storageStatus, err := storage.SetStorage(key, data)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -747,15 +747,15 @@ func storageLoadLength(context unsafe.Pointer, keyOffset int32, keyLength int32)
 	storage := arwen.GetStorageContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.StorageLoad
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
 	}
 
 	data := storage.GetStorage(key)
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.StorageLoad
-	metering.UseGas(gasToUse)
 
 	return int32(len(data))
 }
@@ -766,16 +766,15 @@ func storageLoad(context unsafe.Pointer, keyOffset int32, keyLength int32, dataO
 	storage := arwen.GetStorageContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.StorageLoad
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
 	}
 
 	data := storage.GetStorage(key)
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.StorageLoad
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(data))
-	metering.UseGas(gasToUse)
 
 	err = runtime.MemStore(dataOffset, data)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -1157,6 +1156,9 @@ func executeOnSameContext(
 	runtime := host.Runtime()
 	metering := host.Metering()
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.ExecuteOnSameContext
+	metering.UseGas(gasToUse)
+
 	send := runtime.GetSCAddress()
 	dest, err := runtime.MemLoad(addressOffset, arwen.AddressLen)
 	if arwen.WithFault(err, context, false) {
@@ -1180,8 +1182,7 @@ func executeOnSameContext(
 		return 1
 	}
 
-	gasToUse := metering.GasSchedule().ElrondAPICost.ExecuteOnSameContext
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
 	metering.UseGas(gasToUse)
 
 	bigIntVal := big.NewInt(0).SetBytes(value)

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -73,6 +73,7 @@ import (
 	"github.com/ElrondNetwork/arwen-wasm-vm/wasmer"
 	twos "github.com/ElrondNetwork/big-int-util/twos-complement"
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+	"github.com/ElrondNetwork/elrond-vm-common/parsers"
 )
 
 // ElrondEIImports creates a new wasmer.Imports populated with the ElrondEI API methods
@@ -355,14 +356,14 @@ func getSCAddress(context unsafe.Pointer, resultOffset int32) {
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.GetSCAddress
+	metering.UseGas(gasToUse)
+
 	owner := runtime.GetSCAddress()
 	err := runtime.MemStore(resultOffset, owner)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.GetSCAddress
-	metering.UseGas(gasToUse)
 }
 
 //export getOwnerAddress
@@ -370,6 +371,9 @@ func getOwnerAddress(context unsafe.Pointer, resultOffset int32) {
 	blockchain := arwen.GetBlockchainContext(context)
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
+
+	gasToUse := metering.GasSchedule().ElrondAPICost.GetOwnerAddress
+	metering.UseGas(gasToUse)
 
 	owner, err := blockchain.GetOwnerAddress()
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -380,9 +384,6 @@ func getOwnerAddress(context unsafe.Pointer, resultOffset int32) {
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.GetOwnerAddress
-	metering.UseGas(gasToUse)
 }
 
 //export getShardOfAddress
@@ -391,13 +392,13 @@ func getShardOfAddress(context unsafe.Pointer, addressOffset int32) int32 {
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.GetShardOfAddress
+	metering.UseGas(gasToUse)
+
 	address, err := runtime.MemLoad(addressOffset, arwen.AddressLen)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 0
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.GetShardOfAddress
-	metering.UseGas(gasToUse)
 
 	return int32(blockchain.GetShardOfAddress(address))
 }
@@ -408,13 +409,13 @@ func isSmartContract(context unsafe.Pointer, addressOffset int32) int32 {
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.IsSmartContract
+	metering.UseGas(gasToUse)
+
 	address, err := runtime.MemLoad(addressOffset, arwen.AddressLen)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 0
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.IsSmartContract
-	metering.UseGas(gasToUse)
 
 	isSmartContract := blockchain.IsSmartContract(address)
 	return int32(arwen.BooleanToInt(isSmartContract))
@@ -425,14 +426,14 @@ func signalError(context unsafe.Pointer, messageOffset int32, messageLength int3
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.SignalError
+	metering.UseGas(gasToUse)
+
 	message, err := runtime.MemLoad(messageOffset, messageLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
 	}
 	runtime.SignalUserError(string(message))
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.SignalError
-	metering.UseGas(gasToUse)
 }
 
 //export getExternalBalance
@@ -440,6 +441,9 @@ func getExternalBalance(context unsafe.Pointer, addressOffset int32, resultOffse
 	blockchain := arwen.GetBlockchainContext(context)
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
+
+	gasToUse := metering.GasSchedule().ElrondAPICost.GetExternalBalance
+	metering.UseGas(gasToUse)
 
 	address, err := runtime.MemLoad(addressOffset, arwen.AddressLen)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -452,9 +456,6 @@ func getExternalBalance(context unsafe.Pointer, addressOffset int32, resultOffse
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.GetExternalBalance
-	metering.UseGas(gasToUse)
 }
 
 //export blockHash
@@ -477,9 +478,13 @@ func blockHash(context unsafe.Pointer, nonce int64, resultOffset int32) int32 {
 
 //export transferValue
 func transferValue(context unsafe.Pointer, destOffset int32, valueOffset int32, dataOffset int32, length int32) int32 {
-	runtime := arwen.GetRuntimeContext(context)
-	metering := arwen.GetMeteringContext(context)
-	output := arwen.GetOutputContext(context)
+	host := arwen.GetVmContext(context)
+	runtime := host.Runtime()
+	metering := host.Metering()
+	output := host.Output()
+
+	gasToUse := metering.GasSchedule().ElrondAPICost.TransferValue
+	metering.UseGas(gasToUse)
 
 	send := runtime.GetSCAddress()
 	dest, err := runtime.MemLoad(destOffset, arwen.AddressLen)
@@ -492,14 +497,20 @@ func transferValue(context unsafe.Pointer, destOffset int32, valueOffset int32, 
 		return 1
 	}
 
+	gasToUse = metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(length)
+	metering.UseGas(gasToUse)
+
 	data, err := runtime.MemLoad(dataOffset, length)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 1
 	}
 
-	gasToUse := metering.GasSchedule().ElrondAPICost.TransferValue
-	gasToUse += metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(length)
-	metering.UseGas(gasToUse)
+	// TODO write test for this, after removing vmContextMap
+	argParser := parsers.NewCallArgsParser()
+	functionName, _, err := argParser.ParseData(string(data))
+	if host.IsBuiltinFunctionName(functionName) {
+		return 1
+	}
 
 	err = output.Transfer(dest, send, 0, big.NewInt(0).SetBytes(value), data)
 	if err != nil {
@@ -525,6 +536,8 @@ func createAsyncCall(context unsafe.Pointer,
 ) {
 	host := arwen.GetVmContext(context)
 	runtime := host.Runtime()
+
+	// TODO consume gas
 
 	acIdentifier, err := runtime.MemLoad(asyncContextIdentifier, identifierLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -567,7 +580,6 @@ func createAsyncCall(context unsafe.Pointer,
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
 	}
-
 }
 
 //export setAsyncContextCallback
@@ -579,6 +591,8 @@ func setAsyncContextCallback(context unsafe.Pointer,
 ) int32 {
 	host := arwen.GetVmContext(context)
 	runtime := host.Runtime()
+
+	// TODO consume gas
 
 	acIdentifier, err := runtime.MemLoad(asyncContextIdentifier, identifierLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -606,6 +620,10 @@ func asyncCall(context unsafe.Pointer, destOffset int32, valueOffset int32, data
 	runtime := host.Runtime()
 	metering := host.Metering()
 
+	gasSchedule := metering.GasSchedule()
+	gasToUse := gasSchedule.ElrondAPICost.AsyncCallStep
+	metering.UseGas(gasToUse)
+
 	calledSCAddress, err := runtime.MemLoad(destOffset, arwen.AddressLen)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
@@ -616,15 +634,13 @@ func asyncCall(context unsafe.Pointer, destOffset int32, valueOffset int32, data
 		return
 	}
 
+	gasToUse = gasSchedule.BaseOperationCost.DataCopyPerByte * uint64(length)
+	metering.UseGas(gasToUse)
+
 	data, err := runtime.MemLoad(dataOffset, length)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
 	}
-
-	gasSchedule := metering.GasSchedule()
-	gasToUse := gasSchedule.ElrondAPICost.AsyncCallStep
-	gasToUse += gasSchedule.BaseOperationCost.DataCopyPerByte * uint64(length)
-	metering.UseGas(gasToUse)
 
 	gasLimit := metering.GasLeft()
 
@@ -790,15 +806,15 @@ func setStorageLock(context unsafe.Pointer, keyOffset int32, keyLength int32, lo
 	storage := arwen.GetStorageContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.Int64StorageStore
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
 	}
 
 	timeLockKey := arwen.CustomStorageKey(arwen.TimeLockKeyPrefix, key)
-	gasToUse := metering.GasSchedule().ElrondAPICost.Int64StorageStore
-	metering.UseGas(gasToUse)
-
 	bigTimestamp := big.NewInt(0).SetInt64(lockTimestamp)
 	storageStatus, err := storage.SetStorage(timeLockKey, bigTimestamp.Bytes())
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -813,15 +829,15 @@ func getStorageLock(context unsafe.Pointer, keyOffset int32, keyLength int32) in
 	metering := arwen.GetMeteringContext(context)
 	storage := arwen.GetStorageContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.StorageLoad
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
 	}
 
 	timeLockKey := arwen.CustomStorageKey(arwen.TimeLockKeyPrefix, key)
-	gasToUse := metering.GasSchedule().ElrondAPICost.StorageLoad
-	metering.UseGas(gasToUse)
-
 	data := storage.GetStorage(timeLockKey)
 	timeLock := big.NewInt(0).SetBytes(data).Int64()
 
@@ -853,15 +869,15 @@ func getCaller(context unsafe.Pointer, resultOffset int32) {
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.GetCaller
+	metering.UseGas(gasToUse)
+
 	caller := runtime.GetVMInput().CallerAddr
 
 	err := runtime.MemStore(resultOffset, caller)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.GetCaller
-	metering.UseGas(gasToUse)
 }
 
 //export callValue
@@ -869,11 +885,11 @@ func callValue(context unsafe.Pointer, resultOffset int32) int32 {
 	runtime := arwen.GetRuntimeContext(context)
 	metering := arwen.GetMeteringContext(context)
 
-	value := runtime.GetVMInput().CallValue.Bytes()
-	value = arwen.PadBytesLeft(value, arwen.BalanceLen)
-
 	gasToUse := metering.GasSchedule().ElrondAPICost.GetCallValue
 	metering.UseGas(gasToUse)
+
+	value := runtime.GetVMInput().CallValue.Bytes()
+	value = arwen.PadBytesLeft(value, arwen.BalanceLen)
 
 	err := runtime.MemStore(resultOffset, value)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -888,6 +904,10 @@ func writeLog(context unsafe.Pointer, pointer int32, length int32, topicPtr int3
 	runtime := arwen.GetRuntimeContext(context)
 	output := arwen.GetOutputContext(context)
 	metering := arwen.GetMeteringContext(context)
+
+	gasToUse := metering.GasSchedule().ElrondAPICost.Log
+	gasToUse += metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(numTopics*arwen.HashLen+length)
+	metering.UseGas(gasToUse)
 
 	log, err := runtime.MemLoad(pointer, length)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -907,10 +927,6 @@ func writeLog(context unsafe.Pointer, pointer int32, length int32, topicPtr int3
 	}
 
 	output.WriteLog(runtime.GetSCAddress(), topics, log)
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.Log
-	gasToUse += metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(numTopics*arwen.HashLen+length)
-	metering.UseGas(gasToUse)
 }
 
 //export getBlockTimestamp
@@ -1049,15 +1065,16 @@ func returnData(context unsafe.Pointer, pointer int32, length int32) {
 	output := arwen.GetOutputContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.Finish
+	gasToUse += metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(length)
+	metering.UseGas(gasToUse)
+
 	data, err := runtime.MemLoad(pointer, length)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return
 	}
 
 	output.Finish(data)
-	gasToUse := metering.GasSchedule().ElrondAPICost.Finish
-	gasToUse += metering.GasSchedule().BaseOperationCost.PersistPerByte * uint64(length)
-	metering.UseGas(gasToUse)
 }
 
 //export int64getArgument
@@ -1089,15 +1106,15 @@ func int64storageStore(context unsafe.Pointer, keyOffset int32, keyLength int32,
 	storage := arwen.GetStorageContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.Int64StorageStore
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
 	}
 
 	data := big.NewInt(value)
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.Int64StorageStore
-	metering.UseGas(gasToUse)
 
 	storageStatus, err := storage.SetStorage(key, data.Bytes())
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -1113,6 +1130,9 @@ func int64storageLoad(context unsafe.Pointer, keyOffset int32, keyLength int32) 
 	storage := arwen.GetStorageContext(context)
 	metering := arwen.GetMeteringContext(context)
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.Int64StorageLoad
+	metering.UseGas(gasToUse)
+
 	key, err := runtime.MemLoad(keyOffset, keyLength)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 0
@@ -1122,9 +1142,6 @@ func int64storageLoad(context unsafe.Pointer, keyOffset int32, keyLength int32) 
 
 	bigInt := big.NewInt(0).SetBytes(data)
 
-	gasToUse := metering.GasSchedule().ElrondAPICost.Int64StorageLoad
-	metering.UseGas(gasToUse)
-
 	return bigInt.Int64()
 }
 
@@ -1133,11 +1150,11 @@ func int64finish(context unsafe.Pointer, value int64) {
 	output := arwen.GetOutputContext(context)
 	metering := arwen.GetMeteringContext(context)
 
-	valueBytes := twos.ToBytes(big.NewInt(0).SetInt64(value))
-	output.Finish(valueBytes)
-
 	gasToUse := metering.GasSchedule().ElrondAPICost.Int64Finish
 	metering.UseGas(gasToUse)
+
+	valueBytes := twos.ToBytes(big.NewInt(0).SetInt64(value))
+	output.Finish(valueBytes)
 }
 
 //export executeOnSameContext
@@ -1178,12 +1195,13 @@ func executeOnSameContext(
 		argumentsLengthOffset,
 		dataOffset,
 	)
-	if arwen.WithFault(err, context, false) {
-		return 1
-	}
 
 	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
 	metering.UseGas(gasToUse)
+
+	if arwen.WithFault(err, context, false) {
+		return 1
+	}
 
 	bigIntVal := big.NewInt(0).SetBytes(value)
 	contractCallInput := &vmcommon.ContractCallInput{
@@ -1222,6 +1240,9 @@ func executeOnDestContext(
 	runtime := host.Runtime()
 	metering := host.Metering()
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.ExecuteOnDestContext
+	metering.UseGas(gasToUse)
+
 	send := runtime.GetSCAddress()
 	dest, err := runtime.MemLoad(addressOffset, arwen.AddressLen)
 	if arwen.WithFault(err, context, false) {
@@ -1241,13 +1262,13 @@ func executeOnDestContext(
 		argumentsLengthOffset,
 		dataOffset,
 	)
+
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
+	metering.UseGas(gasToUse)
+
 	if arwen.WithFault(err, context, false) {
 		return 1
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.ExecuteOnDestContext
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
-	metering.UseGas(gasToUse)
 
 	bigIntVal := big.NewInt(0).SetBytes(value)
 	contractCallInput := &vmcommon.ContractCallInput{
@@ -1327,6 +1348,9 @@ func delegateExecution(
 	output := host.Output()
 	metering := host.Metering()
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.DelegateExecution
+	metering.UseGas(gasToUse)
+
 	address, err := runtime.MemLoad(addressOffset, arwen.HashLen)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 1
@@ -1340,16 +1364,16 @@ func delegateExecution(
 		argumentsLengthOffset,
 		dataOffset,
 	)
+
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
+	metering.UseGas(gasToUse)
+
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 1
 	}
 
 	value := runtime.GetVMInput().CallValue
 	sender := runtime.GetVMInput().CallerAddr
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.DelegateExecution
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
-	metering.UseGas(gasToUse)
 
 	err = output.Transfer(address, sender, 0, value, nil)
 	if err != nil {
@@ -1401,6 +1425,9 @@ func executeReadOnly(
 	output := host.Output()
 	metering := host.Metering()
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.ExecuteReadOnly
+	metering.UseGas(gasToUse)
+
 	address, err := runtime.MemLoad(addressOffset, arwen.HashLen)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 1
@@ -1414,16 +1441,16 @@ func executeReadOnly(
 		argumentsLengthOffset,
 		dataOffset,
 	)
+
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
+	metering.UseGas(gasToUse)
+
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 1
 	}
 
 	value := runtime.GetVMInput().CallValue
 	sender := runtime.GetVMInput().CallerAddr
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.ExecuteReadOnly
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
-	metering.UseGas(gasToUse)
 
 	err = output.Transfer(address, sender, 0, value, nil)
 	if err != nil {
@@ -1469,6 +1496,9 @@ func createContract(
 	runtime := host.Runtime()
 	metering := host.Metering()
 
+	gasToUse := metering.GasSchedule().ElrondAPICost.CreateContract
+	metering.UseGas(gasToUse)
+
 	sender := runtime.GetSCAddress()
 	value, err := runtime.MemLoad(valueOffset, arwen.BalanceLen)
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
@@ -1488,13 +1518,13 @@ func createContract(
 		argumentsLengthOffset,
 		dataOffset,
 	)
+
+	gasToUse = metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
+	metering.UseGas(gasToUse)
+
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return 1
 	}
-
-	gasToUse := metering.GasSchedule().ElrondAPICost.CreateContract
-	gasToUse += metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(actualLen)
-	metering.UseGas(gasToUse)
 
 	contractCreate := &vmcommon.ContractCreateInput{
 		VMInput: vmcommon.VMInput{

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -771,7 +771,7 @@ func storageLoadLength(context unsafe.Pointer, keyOffset int32, keyLength int32)
 		return -1
 	}
 
-	data := storage.GetStorage(key)
+	data := storage.GetStorageUnmetered(key)
 
 	return int32(len(data))
 }

--- a/arwen/ethapi/ethereumei.go
+++ b/arwen/ethapi/ethereumei.go
@@ -361,8 +361,6 @@ func ethstorageLoad(context unsafe.Pointer, pathOffset int32, resultOffset int32
 	}
 
 	data := storage.GetStorage(key)
-	dataGasToUse := metering.GasSchedule().BaseOperationCost.DataCopyPerByte * uint64(len(data))
-	metering.UseGas(dataGasToUse)
 
 	currInput := make([]byte, arwen.HashLen)
 	copy(currInput[arwen.HashLen-len(data):], data)

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -69,7 +69,7 @@ func (host *vmHost) determineAsyncCallExecutionMode(asyncCallInfo *arwen.AsyncCa
 	shardOfDest := blockchain.GetShardOfAddress(asyncCallInfo.Destination)
 	sameShard := shardOfSC == shardOfDest
 
-	if host.isBuiltinFunctionName(functionName) {
+	if host.IsBuiltinFunctionName(functionName) {
 		if sameShard {
 			return arwen.SyncCall, nil
 		}

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -521,7 +521,7 @@ func (host *vmHost) processCallbackStack() error {
 	storage := host.Storage()
 
 	storageKey := arwen.CustomStorageKey(arwen.AsyncDataPrefix, runtime.GetOriginalTxHash())
-	buff := storage.GetStorage(storageKey)
+	buff := storage.GetStorageUnmetered(storageKey)
 	if len(buff) == 0 {
 		return nil
 	}
@@ -693,7 +693,7 @@ func (host *vmHost) getCurrentAsyncInfo() (*arwen.AsyncContextInfo, error) {
 
 	asyncInfo := &arwen.AsyncContextInfo{}
 	storageKey := arwen.CustomStorageKey(arwen.AsyncDataPrefix, runtime.GetOriginalTxHash())
-	buff := storage.GetStorage(storageKey)
+	buff := storage.GetStorageUnmetered(storageKey)
 	if len(buff) == 0 {
 		return asyncInfo, nil
 	}

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -284,7 +284,7 @@ func (host *vmHost) CreateNewContract(input *vmcommon.ContractCreateInput) (newC
 	codeDeployInput := arwen.CodeDeployInput{
 		ContractCode:         input.ContractCode,
 		ContractCodeMetadata: input.ContractCodeMetadata,
-		ContractAddress:      newContractAddress,
+		ContractAddress:      nil,
 	}
 	err = metering.DeductInitialGasForIndirectDeployment(codeDeployInput)
 	if err != nil {
@@ -301,14 +301,13 @@ func (host *vmHost) CreateNewContract(input *vmcommon.ContractCreateInput) (newC
 		return
 	}
 
-	newContractAccount, isNew := output.GetOutputAccount(newContractAddress)
-	if !isNew {
+	if blockchain.AccountExists(newContractAddress) {
 		err = arwen.ErrDeploymentOverExistingAccount
 		return
 	}
 
-	newContractAccount.Code = input.ContractCode
-	newContractAccount.CodeMetadata = input.ContractCodeMetadata
+	codeDeployInput.ContractAddress = newContractAddress
+	output.DeployCode(codeDeployInput)
 
 	defer func() {
 		if err != nil {

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -261,10 +261,10 @@ func (host *vmHost) isInitFunctionBeingCalled() bool {
 
 func (host *vmHost) isBuiltinFunctionBeingCalled() bool {
 	functionName := host.Runtime().Function()
-	return host.isBuiltinFunctionName(functionName)
+	return host.IsBuiltinFunctionName(functionName)
 }
 
-func (host *vmHost) isBuiltinFunctionName(functionName string) bool {
+func (host *vmHost) IsBuiltinFunctionName(functionName string) bool {
 	_, ok := host.protocolBuiltinFunctions[functionName]
 	return ok
 }

--- a/arwen/host/execution_vmoutputs_test.go
+++ b/arwen/host/execution_vmoutputs_test.go
@@ -54,7 +54,6 @@ func expectedVMOutput_SameCtx_Prepare(code []byte) *vmcommon.VMOutput {
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = code
 
 	_ = AddNewOutputAccount(
 		vmOutput,
@@ -110,7 +109,6 @@ func expectedVMOutput_SameCtx_OutOfGas(parentCode []byte, childCode []byte) *vmc
 		0,
 		nil,
 	)
-	parentAccount.Code = parentCode
 
 	SetStorageUpdate(parentAccount, parentKeyA, parentDataA)
 	SetStorageUpdate(parentAccount, parentKeyB, parentDataB)
@@ -146,7 +144,6 @@ func expectedVMOutput_SameCtx_SuccessfulChildCall(parentCode []byte, childCode [
 		nil,
 	)
 	childAccount.Balance = big.NewInt(0)
-	childAccount.Code = childCode
 
 	_ = AddNewOutputAccount(
 		vmOutput,
@@ -200,16 +197,14 @@ func expectedVMOutput_SameCtx_SuccessfulChildCall_BigInts(parentCode []byte, chi
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = parentCode
 	// parentAccount.BalanceDelta = big.NewInt(-99)
 
-	childAccount := AddNewOutputAccount(
+	_ = AddNewOutputAccount(
 		vmOutput,
 		childAddress,
 		99,
 		nil,
 	)
-	childAccount.Code = childCode
 
 	// The child SC will output "child ok" if it could read some expected Big
 	// Ints directly from the parent's context.
@@ -243,7 +238,6 @@ func expectedVMOutput_SameCtx_Recursive_Direct(code []byte, recursiveCalls int) 
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
-	account.Code = code
 
 	for i := recursiveCalls; i >= 0; i-- {
 		finishString := fmt.Sprintf("Rfinish%03d", i)
@@ -275,7 +269,6 @@ func expectedVMOutput_SameCtx_Recursive_Direct_ErrMaxInstances(code []byte, recu
 		0,
 		nil,
 	)
-	account.Code = code
 
 	finishString := fmt.Sprintf("Rfinish%03d", recursiveCalls)
 	AddFinishData(vmOutput, []byte(finishString))
@@ -301,7 +294,6 @@ func expectedVMOutput_SameCtx_Recursive_MutualMethods(code []byte, recursiveCall
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
-	account.Code = code
 
 	SetStorageUpdate(account, recursiveIterationCounterKey, []byte{byte(recursiveCalls + 1)})
 	SetStorageUpdate(account, recursiveIterationBigCounterKey, big.NewInt(int64(recursiveCalls+1)).Bytes())
@@ -345,7 +337,6 @@ func expectedVMOutput_SameCtx_Recursive_MutualSCs(parentCode []byte, childCode [
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = parentCode
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -354,7 +345,6 @@ func expectedVMOutput_SameCtx_Recursive_MutualSCs(parentCode []byte, childCode [
 		nil,
 	)
 	childAccount.Balance = big.NewInt(0)
-	childAccount.Code = childCode
 
 	if recursiveCalls%2 == 1 {
 		parentAccount.BalanceDelta = big.NewInt(-5)
@@ -402,7 +392,6 @@ func expectedVMOutput_SameCtx_BuiltinFunctions_1(code []byte) *vmcommon.VMOutput
 		nil,
 	)
 	account.Balance = big.NewInt(1000)
-	account.Code = code
 
 	AddFinishData(vmOutput, []byte("succ"))
 	gasConsumed_builtinClaim := 100
@@ -422,7 +411,6 @@ func expectedVMOutput_SameCtx_BuiltinFunctions_2(code []byte) *vmcommon.VMOutput
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0)
-	account.Code = code
 
 	AddFinishData(vmOutput, []byte("succ"))
 
@@ -435,13 +423,12 @@ func expectedVMOutput_SameCtx_BuiltinFunctions_2(code []byte) *vmcommon.VMOutput
 func expectedVMOutput_SameCtx_BuiltinFunctions_3(code []byte) *vmcommon.VMOutput {
 	vmOutput := MakeVMOutput()
 
-	account := AddNewOutputAccount(
+	_ = AddNewOutputAccount(
 		vmOutput,
 		parentAddress,
 		0,
 		nil,
 	)
-	account.Code = code
 
 	AddFinishData(vmOutput, []byte("fail"))
 	vmOutput.GasRemaining = 98000
@@ -460,7 +447,6 @@ func expectedVMOutput_DestCtx_Prepare(code []byte) *vmcommon.VMOutput {
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = code
 
 	_ = AddNewOutputAccount(
 		vmOutput,
@@ -519,7 +505,6 @@ func expectedVMOutput_DestCtx_OutOfGas(parentCode []byte) *vmcommon.VMOutput {
 		0,
 		nil,
 	)
-	parentAccount.Code = parentCode
 
 	SetStorageUpdate(parentAccount, parentKeyA, parentDataA)
 	SetStorageUpdate(parentAccount, parentKeyB, parentDataB)
@@ -547,7 +532,6 @@ func expectedVMOutput_DestCtx_SuccessfulChildCall(parentCode []byte, childCode [
 
 	parentAccount := vmOutput.OutputAccounts[string(parentAddress)]
 	parentAccount.BalanceDelta = big.NewInt(-141)
-	parentAccount.Code = parentCode
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -556,7 +540,6 @@ func expectedVMOutput_DestCtx_SuccessfulChildCall(parentCode []byte, childCode [
 		nil,
 	)
 	childAccount.Balance = big.NewInt(0)
-	childAccount.Code = childCode
 
 	_ = AddNewOutputAccount(
 		vmOutput,
@@ -597,15 +580,13 @@ func expectedVMOutput_DestCtx_SuccessfulChildCall_BigInts(parentCode []byte, chi
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = parentCode
 
-	childAccount := AddNewOutputAccount(
+	_ = AddNewOutputAccount(
 		vmOutput,
 		childAddress,
 		99,
 		nil,
 	)
-	childAccount.Code = childCode
 
 	// The child SC will output "child ok" if it could NOT read the Big Ints from
 	// the parent's context.
@@ -639,7 +620,6 @@ func expectedVMOutput_DestCtx_Recursive_Direct(code []byte, recursiveCalls int) 
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
-	account.Code = code
 
 	for i := recursiveCalls; i >= 0; i-- {
 		finishString := fmt.Sprintf("Rfinish%03d", i)
@@ -673,7 +653,6 @@ func expectedVMOutput_DestCtx_Recursive_MutualMethods(code []byte, recursiveCall
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
-	account.Code = code
 
 	SetStorageUpdate(account, recursiveIterationCounterKey, []byte{byte(recursiveCalls + 1)})
 	SetStorageUpdate(account, recursiveIterationBigCounterKey, big.NewInt(int64(1)).Bytes())
@@ -723,7 +702,6 @@ func expectedVMOutput_DestCtx_Recursive_MutualSCs(parentCode []byte, childCode [
 	)
 	parentAccount.Balance = big.NewInt(1000)
 	parentAccount.BalanceDelta = big.NewInt(-balanceDelta)
-	parentAccount.Code = parentCode
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -733,7 +711,6 @@ func expectedVMOutput_DestCtx_Recursive_MutualSCs(parentCode []byte, childCode [
 	)
 	childAccount.Balance = big.NewInt(0)
 	childAccount.BalanceDelta = big.NewInt(balanceDelta)
-	childAccount.Code = childCode
 
 	for i := 0; i <= recursiveCalls; i++ {
 		var finishData string
@@ -780,7 +757,6 @@ func expectedVMOutput_AsyncCall(parentCode []byte, childCode []byte) *vmcommon.V
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = parentCode
 	SetStorageUpdate(parentAccount, parentKeyA, parentDataA)
 	SetStorageUpdate(parentAccount, parentKeyB, parentDataB)
 	AddFinishData(vmOutput, parentFinishA)
@@ -800,7 +776,6 @@ func expectedVMOutput_AsyncCall(parentCode []byte, childCode []byte) *vmcommon.V
 		nil,
 	)
 	childAccount.Balance = big.NewInt(0)
-	childAccount.Code = childCode
 	SetStorageUpdate(childAccount, childKey, childData)
 
 	_ = AddNewOutputAccount(
@@ -829,7 +804,6 @@ func expectedVMOutput_AsyncCall_ChildFails(parentCode []byte, childCode []byte) 
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = parentCode
 	SetStorageUpdate(parentAccount, parentKeyA, parentDataA)
 	SetStorageUpdate(parentAccount, parentKeyB, parentDataB)
 	AddFinishData(vmOutput, parentFinishA)
@@ -849,7 +823,6 @@ func expectedVMOutput_AsyncCall_ChildFails(parentCode []byte, childCode []byte) 
 		nil,
 	)
 	childAccount.Balance = big.NewInt(0)
-	childAccount.Code = childCode
 
 	_ = AddNewOutputAccount(
 		vmOutput,
@@ -873,7 +846,6 @@ func expectedVMOutput_AsyncCall_CallBackFails(parentCode []byte, childCode []byt
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = parentCode
 	SetStorageUpdate(parentAccount, parentKeyA, parentDataA)
 	SetStorageUpdate(parentAccount, parentKeyB, parentDataB)
 	AddFinishData(vmOutput, parentFinishA)
@@ -894,7 +866,6 @@ func expectedVMOutput_AsyncCall_CallBackFails(parentCode []byte, childCode []byt
 	)
 	childAccount.Balance = big.NewInt(0)
 	childAccount.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
-	childAccount.Code = childCode
 	SetStorageUpdate(childAccount, childKey, childData)
 
 	_ = AddNewOutputAccount(

--- a/arwen/host/execution_vmoutputs_test.go
+++ b/arwen/host/execution_vmoutputs_test.go
@@ -172,7 +172,7 @@ func expectedVMOutput_SameCtx_SuccessfulChildCall(parentCode []byte, childCode [
 
 	parentGasBeforeExecuteAPI := uint64(197)
 	executeAPICost := uint64(39)
-	childExecutionCost := uint64(431)
+	childExecutionCost := uint64(462)
 	finalCost := uint64(139)
 	gas := gasProvided
 	gas -= parentCompilationCost_SameCtx

--- a/arwen/host/execution_vmoutputs_test.go
+++ b/arwen/host/execution_vmoutputs_test.go
@@ -922,7 +922,6 @@ func expectedVMOutput_CreateNewContract_Success(parentCode []byte, childCode []b
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.Code = parentCode
 	parentAccount.Nonce = 1
 	SetStorageUpdate(parentAccount, []byte{'A'}, childCode)
 
@@ -951,7 +950,6 @@ func expectedVMOutput_CreateNewContract_Fail(parentCode []byte, childCode []byte
 		0,
 		nil,
 	)
-	parentAccount.Code = parentCode
 	parentAccount.Nonce = 0
 	SetStorageUpdate(parentAccount, []byte{'A'}, childCode)
 

--- a/arwen/host/execution_vmoutputs_test.go
+++ b/arwen/host/execution_vmoutputs_test.go
@@ -172,7 +172,7 @@ func expectedVMOutput_SameCtx_SuccessfulChildCall(parentCode []byte, childCode [
 
 	parentGasBeforeExecuteAPI := uint64(197)
 	executeAPICost := uint64(39)
-	childExecutionCost := uint64(462)
+	childExecutionCost := uint64(431)
 	finalCost := uint64(139)
 	gas := gasProvided
 	gas -= parentCompilationCost_SameCtx

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -178,6 +178,7 @@ type StorageContext interface {
 	SetAddress(address []byte)
 	GetStorageUpdates(address []byte) map[string]*vmcommon.StorageUpdate
 	GetStorage(key []byte) []byte
+	GetStorageUnmetered(key []byte) []byte
 	SetStorage(key []byte, value []byte) (StorageStatus, error)
 }
 

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -37,6 +37,7 @@ type VMHost interface {
 	EthereumCallData() []byte
 	GetAPIMethods() *wasmer.Imports
 	GetProtocolBuiltinFunctions() vmcommon.FunctionNames
+	IsBuiltinFunctionName(functionName string) bool
 }
 
 type BlockchainContext interface {

--- a/mock/vmHostMock.go
+++ b/mock/vmHostMock.go
@@ -21,7 +21,8 @@ type VmHostMock struct {
 	StorageContext    arwen.StorageContext
 	BigIntContext     arwen.BigIntContext
 
-	SCAPIMethods *wasmer.Imports
+	SCAPIMethods  *wasmer.Imports
+	IsBuiltinFunc bool
 }
 
 func (host *VmHostMock) Crypto() vmcommon.CryptoHook {
@@ -86,4 +87,8 @@ func (host *VmHostMock) GetAPIMethods() *wasmer.Imports {
 
 func (host *VmHostMock) GetProtocolBuiltinFunctions() vmcommon.FunctionNames {
 	return make(vmcommon.FunctionNames)
+}
+
+func (host *VmHostMock) IsBuiltinFunctionName(functionName string) bool {
+	return host.IsBuiltinFunc
 }

--- a/mock/vmHostStub.go
+++ b/mock/vmHostStub.go
@@ -27,6 +27,7 @@ type VmHostStub struct {
 	EthereumCallDataCalled            func() []byte
 	GetAPIMethodsCalled               func() *wasmer.Imports
 	GetProtocolBuiltinFunctionsCalled func() vmcommon.FunctionNames
+	IsBuiltinFunctionNameCalled       func(functionName string) bool
 }
 
 func (vhs *VmHostStub) InitState() {
@@ -142,4 +143,11 @@ func (vhs *VmHostStub) GetProtocolBuiltinFunctions() vmcommon.FunctionNames {
 		return vhs.GetProtocolBuiltinFunctionsCalled()
 	}
 	return make(vmcommon.FunctionNames)
+}
+
+func (vhs *VmHostStub) IsBuiltinFunctionName(functionName string) bool {
+	if vhs.IsBuiltinFunctionNameCalled != nil {
+		return vhs.IsBuiltinFunctionNameCalled(functionName)
+	}
+	return false
 }


### PR DESCRIPTION
This PR contains the following changes:
* `outputContext.GetStorage()` and `outputContext.SetStorage()` now consume gas based on the length of the provided key, if the key is longer than 32 bytes.
* Calling `outputContext.GetStorage()` now consumes gas directly, so that the API functions that call it do not have to calculate the length of the data loaded from storage themselves.
* Added the function `outputContext.GetStorageUnmetered()`, which retrieves data from storage without metering. It is used as a utility by other methods, but it is never called directly by API functions that are called by smart contracts, except in `storageLoadLength()`.
* Added proper protection against overwriting existing SCs when using `createContract()`. Previous implementation provided only superficial and incomplete protection.
* Added protection against calling any built-in function using `transferValue()`, using an argument parser.
* Added a clean-up phase when generating the `VMOutput`, which removes from `OutputAccounts` all the `.Code` fields that were not actually deployed or upgraded. This prevents the unchanged code of smart contracts from being propagated back to the node via the `VMOutput`, just because the code was retrieved at some point during execution.
* Many API functions in `elrondei.go` and `bigintOps.go` have been changed to consume gas before returning in case of error. This prevents abusive repeated calls to expensive API functions which end up failing, but without any gas consumption.

TODO: 
* tests for gas consumption for keys longer than 32 bytes
* tests for protecting against calls to built-in functions with `transferValue()`