### PR TITLE
Fix serialization for IPC messages

### DIFF
--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -328,8 +328,8 @@ func (context *outputContext) AddToActiveState(rightOutput *vmcommon.VMOutput) {
 		rightOutput.GasRefund.Add(rightOutput.GasRefund, context.outputState.GasRefund)
 	}
 
-	for _, rightAccount := range rightOutput.OutputAccounts {
-		leftAccount, ok := context.outputState.OutputAccounts[string(rightAccount.Address)]
+	for address, rightAccount := range rightOutput.OutputAccounts {
+		leftAccount, ok := context.outputState.OutputAccounts[address]
 		if !ok || rightAccount.BalanceDelta == nil {
 			continue
 		}
@@ -345,11 +345,12 @@ func mergeVMOutputs(leftOutput *vmcommon.VMOutput, rightOutput *vmcommon.VMOutpu
 	if leftOutput.OutputAccounts == nil {
 		leftOutput.OutputAccounts = make(map[string]*vmcommon.OutputAccount)
 	}
-	for _, rightAccount := range rightOutput.OutputAccounts {
-		leftAccount, ok := leftOutput.OutputAccounts[string(rightAccount.Address)]
+
+	for address, rightAccount := range rightOutput.OutputAccounts {
+		leftAccount, ok := leftOutput.OutputAccounts[address]
 		if !ok {
 			leftAccount = &vmcommon.OutputAccount{}
-			leftOutput.OutputAccounts[string(rightAccount.Address)] = leftAccount
+			leftOutput.OutputAccounts[address] = leftAccount
 		}
 		mergeOutputAccounts(leftAccount, rightAccount)
 	}

--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -328,8 +328,8 @@ func (context *outputContext) AddToActiveState(rightOutput *vmcommon.VMOutput) {
 		rightOutput.GasRefund.Add(rightOutput.GasRefund, context.outputState.GasRefund)
 	}
 
-	for address, rightAccount := range rightOutput.OutputAccounts {
-		leftAccount, ok := context.outputState.OutputAccounts[address]
+	for _, rightAccount := range rightOutput.OutputAccounts {
+		leftAccount, ok := context.outputState.OutputAccounts[string(rightAccount.Address)]
 		if !ok || rightAccount.BalanceDelta == nil {
 			continue
 		}
@@ -346,11 +346,11 @@ func mergeVMOutputs(leftOutput *vmcommon.VMOutput, rightOutput *vmcommon.VMOutpu
 		leftOutput.OutputAccounts = make(map[string]*vmcommon.OutputAccount)
 	}
 
-	for address, rightAccount := range rightOutput.OutputAccounts {
-		leftAccount, ok := leftOutput.OutputAccounts[address]
+	for _, rightAccount := range rightOutput.OutputAccounts {
+		leftAccount, ok := leftOutput.OutputAccounts[string(rightAccount.Address)]
 		if !ok {
 			leftAccount = &vmcommon.OutputAccount{}
-			leftOutput.OutputAccounts[address] = leftAccount
+			leftOutput.OutputAccounts[string(rightAccount.Address)] = leftAccount
 		}
 		mergeOutputAccounts(leftAccount, rightAccount)
 	}

--- a/ipc/arwenpart/blockchainGateway.go
+++ b/ipc/arwenpart/blockchainGateway.go
@@ -266,7 +266,7 @@ func (blockchain *BlockchainHookGateway) ProcessBuiltInFunction(input *vmcommon.
 	}
 
 	response := rawResponse.(*common.MessageBlockchainProcessBuiltinFunctionResponse)
-	return response.VMOutput, response.GetError()
+	return response.SerializableVMOutput.ConvertToVMOutput(), response.GetError()
 }
 
 // GetBuiltinFunctionNames forwards a message to the actual hook
@@ -298,7 +298,7 @@ func (blockchain *BlockchainHookGateway) GetAllState(address []byte) (map[string
 	}
 
 	response := rawResponse.(*common.MessageBlockchainGetAllStateResponse)
-	return response.AllState, response.GetError()
+	return response.SerializableAllState.ConvertToMap(), response.GetError()
 }
 
 // GetUserAccount forwards a message to the actual hook

--- a/ipc/common/messagesBlockchain.go
+++ b/ipc/common/messagesBlockchain.go
@@ -412,14 +412,14 @@ func NewMessageBlockchainProcessBuiltinFunctionRequest(callInput vmcommon.Contra
 // MessageBlockchainProcessBuiltinFunctionResponse represents a response message
 type MessageBlockchainProcessBuiltinFunctionResponse struct {
 	Message
-	VMOutput *vmcommon.VMOutput
+	SerializableVMOutput *SerializableVMOutput
 }
 
 // NewMessageBlockchainProcessBuiltinFunctionResponse creates a response message
 func NewMessageBlockchainProcessBuiltinFunctionResponse(vmOutput *vmcommon.VMOutput, err error) *MessageBlockchainProcessBuiltinFunctionResponse {
 	message := &MessageBlockchainProcessBuiltinFunctionResponse{}
 	message.Kind = BlockchainProcessBuiltinFunctionResponse
-	message.VMOutput = vmOutput
+	message.SerializableVMOutput = NewSerializableVMOutput(vmOutput)
 	message.SetError(err)
 	return message
 }
@@ -469,15 +469,14 @@ func NewMessageBlockchainGetAllStateRequest(address []byte) *MessageBlockchainGe
 // MessageBlockchainGetAllStateResponse represents a response message
 type MessageBlockchainGetAllStateResponse struct {
 	Message
-	// TODO: Make sure to change "map[string][]byte" to a JSON-serializable friendly structure when "GetAllState()" will be used
-	AllState map[string][]byte
+	SerializableAllState *SerializableMapStringBytes
 }
 
 // NewMessageBlockchainGetAllStateResponse creates a response message
 func NewMessageBlockchainGetAllStateResponse(state map[string][]byte, err error) *MessageBlockchainGetAllStateResponse {
 	message := &MessageBlockchainGetAllStateResponse{}
 	message.Kind = BlockchainGetAllStateResponse
-	message.AllState = state
+	message.SerializableAllState = NewSerializableMapStringBytes(state)
 	message.SetError(err)
 	return message
 }

--- a/ipc/common/messages_test.go
+++ b/ipc/common/messages_test.go
@@ -51,6 +51,16 @@ func TestMessageContractResponse_CanWrapNilVMOutput(t *testing.T) {
 	requireSerializationConsistency(t, message, &MessageContractResponse{})
 }
 
+func TestMessageBlockchainProcessBuiltinFunctionResponse_IsConsistentlySerializable(t *testing.T) {
+	vmOutput := &vmcommon.VMOutput{OutputAccounts: make(map[string]*vmcommon.OutputAccount)}
+	vmOutput.OutputAccounts["alice"] = &vmcommon.OutputAccount{Address: []byte("alice")}
+	// Non UTF-8 as output account keys
+	vmOutput.OutputAccounts[string([]byte{0, 129})] = &vmcommon.OutputAccount{Address: []byte{0, 129}}
+	vmOutput.OutputAccounts[string([]byte{0, 128})] = &vmcommon.OutputAccount{Address: []byte{0, 128}}
+	message := NewMessageBlockchainProcessBuiltinFunctionResponse(vmOutput, nil)
+	requireSerializationConsistency(t, message, &MessageBlockchainProcessBuiltinFunctionResponse{})
+}
+
 func TestMessageBlockchainGetAllStateResponse_IsConsistentlySerializable(t *testing.T) {
 	allState := make(map[string][]byte)
 	allState["foo"] = []byte{0}

--- a/ipc/common/messages_test.go
+++ b/ipc/common/messages_test.go
@@ -52,8 +52,6 @@ func TestMessageContractResponse_CanWrapNilVMOutput(t *testing.T) {
 }
 
 func TestMessageBlockchainGetAllStateResponse_IsConsistentlySerializable(t *testing.T) {
-	t.Skip("GetAllState isn't used at this moment")
-
 	allState := make(map[string][]byte)
 	allState["foo"] = []byte{0}
 	allState[string([]byte{0})] = []byte{0}

--- a/ipc/common/serializableMaps.go
+++ b/ipc/common/serializableMaps.go
@@ -1,0 +1,32 @@
+package common
+
+type SerializableMapStringBytes struct {
+	Keys   [][]byte
+	Values [][]byte
+}
+
+func NewSerializableMapStringBytes(data map[string][]byte) *SerializableMapStringBytes {
+	s := &SerializableMapStringBytes{
+		Keys:   make([][]byte, 0, len(data)),
+		Values: make([][]byte, 0, len(data)),
+	}
+
+	for key, value := range data {
+		s.Keys = append(s.Keys, []byte(key))
+		s.Values = append(s.Values, value)
+	}
+
+	return s
+}
+
+func (s *SerializableMapStringBytes) ConvertToMap() map[string][]byte {
+	m := make(map[string][]byte)
+
+	for i := 0; i < len(s.Keys); i++ {
+		key := string(s.Keys[i])
+		value := s.Values[i]
+		m[key] = value
+	}
+
+	return m
+}


### PR DESCRIPTION
Fix serialization for IPC messages:
 - built-in function calls (vm output)
 - `getAllState`