### PR TITLE
Fix panic in async out-of-gas case

### DIFF
--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -293,6 +293,12 @@ func (host *vmHost) processCallbackVMOutput(callbackVMOutput *vmcommon.VMOutput,
 	output := host.Output()
 
 	runtime.GetVMInput().GasProvided = 0
+
+	if callbackVMOutput == nil {
+		callbackVMOutput = output.CreateVMOutputInCaseOfError(callBackErr)
+	}
+
+	output.SetReturnMessage(callbackVMOutput.ReturnMessage)
 	output.Finish([]byte(callbackVMOutput.ReturnCode.String()))
 	output.Finish([]byte(runtime.GetCurrentTxHash()))
 

--- a/arwen/host/execution_test.go
+++ b/arwen/host/execution_test.go
@@ -1093,7 +1093,7 @@ func TestExecution_AsyncCall_BuiltinFails(t *testing.T) {
 }
 
 func TestExecution_AsyncCall_CallBackFailsBeforeExecution(t *testing.T) {
-	config.AsyncCallbackGasLockForTests = 2
+	config.AsyncCallbackGasLockForTests = uint64(2)
 
 	code := GetTestSCCode("async-call-builtin", "../../")
 	scBalance := big.NewInt(1000)

--- a/arwen/host/execution_vmoutputs_test.go
+++ b/arwen/host/execution_vmoutputs_test.go
@@ -881,6 +881,8 @@ func expectedVMOutput_AsyncCall_CallBackFails(parentCode []byte, childCode []byt
 	AddFinishData(vmOutput, []byte("user error"))
 	AddFinishData(vmOutput, []byte("txhash"))
 
+	vmOutput.ReturnMessage = "callBack error"
+
 	return vmOutput
 }
 

--- a/arwen/host/testInitializer.go
+++ b/arwen/host/testInitializer.go
@@ -25,6 +25,8 @@ var userAddress = []byte("userAccount.....................")
 var parentAddress = []byte("parentSC........................")
 var childAddress = []byte("childSC.........................")
 
+var CustomGasSchedule = config.GasScheduleMap(nil)
+
 // GetSCCode retrieves the bytecode of a WASM module from a file
 func GetSCCode(fileName string) []byte {
 	code, err := ioutil.ReadFile(filepath.Clean(fileName))
@@ -101,10 +103,15 @@ func DefaultTestArwenForTwoSCs(t *testing.T, parentCode []byte, childCode []byte
 }
 
 func DefaultTestArwen(tb testing.TB, blockchain vmcommon.BlockchainHook, crypto vmcommon.CryptoHook) (*vmHost, error) {
+	gasSchedule := CustomGasSchedule
+	if gasSchedule == nil {
+		gasSchedule = config.MakeGasMapForTests()
+	}
+
 	host, err := NewArwenVM(blockchain, crypto, &arwen.VMHostParameters{
 		VMType:                   defaultVMType,
 		BlockGasLimit:            uint64(1000),
-		GasSchedule:              config.MakeGasMapForTests(),
+		GasSchedule:              gasSchedule,
 		ProtocolBuiltinFunctions: make(vmcommon.FunctionNames),
 		ElrondProtectedKeyPrefix: []byte("ELROND"),
 	})

--- a/config/gasSchedule.go
+++ b/config/gasSchedule.go
@@ -8,7 +8,8 @@ import (
 )
 
 const GasValueForTests = 1
-const AsyncCallbackGasLockForTests = 100_000
+
+var AsyncCallbackGasLockForTests = 100_000
 
 // GasScheduleMap (alias) is the map for gas schedule
 type GasScheduleMap = map[string]map[string]uint64
@@ -731,5 +732,5 @@ func FillGasMap_WASMOpcodeValues(value uint64) map[string]uint64 {
 }
 
 func MakeGasMapForTests() GasScheduleMap {
-	return MakeGasMap(GasValueForTests, AsyncCallbackGasLockForTests)
+	return MakeGasMap(GasValueForTests, uint64(AsyncCallbackGasLockForTests))
 }

--- a/config/gasSchedule.go
+++ b/config/gasSchedule.go
@@ -9,7 +9,7 @@ import (
 
 const GasValueForTests = 1
 
-var AsyncCallbackGasLockForTests = 100_000
+var AsyncCallbackGasLockForTests = uint64(100_000)
 
 // GasScheduleMap (alias) is the map for gas schedule
 type GasScheduleMap = map[string]map[string]uint64
@@ -732,5 +732,5 @@ func FillGasMap_WASMOpcodeValues(value uint64) map[string]uint64 {
 }
 
 func MakeGasMapForTests() GasScheduleMap {
-	return MakeGasMap(GasValueForTests, uint64(AsyncCallbackGasLockForTests))
+	return MakeGasMap(GasValueForTests, AsyncCallbackGasLockForTests)
 }


### PR DESCRIPTION
Fixed a `nil pointer dereferencing` panic, in case the async callback step had too little gas to even compile.