### PR TITLE
Add binary version to Arwen, with IPC API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test test-short build arwen arwendebug clean
 
+ARWEN_VERSION := $(shell git describe --tags --long --dirty)
+
 clean:
 	go clean -cache -testcache
 
@@ -7,7 +9,7 @@ build:
 	go build ./...
 
 arwen:
-	go build -o ./cmd/arwen/arwen ./cmd/arwen
+	go build -ldflags="-X main.appVersion=$(ARWEN_VERSION)" -o ./cmd/arwen/arwen ./cmd/arwen
 	cp ./cmd/arwen/arwen ./ipc/tests
 	cp ./cmd/arwen/arwen ${ARWEN_PATH}
 

--- a/cmd/arwen/main.go
+++ b/cmd/arwen/main.go
@@ -18,6 +18,8 @@ const (
 	fileDescriptorLogToNode      = 7
 )
 
+var appVersion = "undefined"
+
 func main() {
 	errCode, errMessage := doMain()
 	if errCode != common.ErrCodeSuccess {
@@ -74,6 +76,7 @@ func doMain() (int, string) {
 	defer logsPart.StopLoop()
 
 	part, err := arwenpart.NewArwenPart(
+		appVersion,
 		nodeToArwenFile,
 		arwenToNodeFile,
 		&arwenArguments.VMHostParameters,

--- a/ipc/arwenpart/part.go
+++ b/ipc/arwenpart/part.go
@@ -19,10 +19,12 @@ type ArwenPart struct {
 	Messenger *ArwenMessenger
 	VMHost    vmcommon.VMExecutionHandler
 	Repliers  []common.MessageReplier
+	Version   string
 }
 
 // NewArwenPart creates the Arwen part
 func NewArwenPart(
+	version string,
 	input *os.File,
 	output *os.File,
 	vmHostParameters *arwen.VMHostParameters,
@@ -44,12 +46,14 @@ func NewArwenPart(
 	part := &ArwenPart{
 		Messenger: messenger,
 		VMHost:    newArwenHost,
+		Version:   version,
 	}
 
 	part.Repliers = common.CreateReplySlots(part.noopReplier)
 	part.Repliers[common.ContractDeployRequest] = part.replyToRunSmartContractCreate
 	part.Repliers[common.ContractCallRequest] = part.replyToRunSmartContractCall
 	part.Repliers[common.DiagnoseWaitRequest] = part.replyToDiagnoseWait
+	part.Repliers[common.VersionRequest] = part.replyToVersionRequest
 
 	return part, nil
 }
@@ -113,4 +117,8 @@ func (part *ArwenPart) replyToDiagnoseWait(request common.MessageHandler) common
 	duration := time.Duration(int64(typedRequest.Milliseconds) * int64(time.Millisecond))
 	time.Sleep(duration)
 	return common.NewMessageDiagnoseWaitResponse()
+}
+
+func (part *ArwenPart) replyToVersionRequest(request common.MessageHandler) common.MessageHandler {
+	return common.NewMessageVersionResponse(part.Version)
 }

--- a/ipc/common/messages.go
+++ b/ipc/common/messages.go
@@ -59,6 +59,8 @@ const (
 	BlockchainIsSmartContractResponse
 	DiagnoseWaitRequest
 	DiagnoseWaitResponse
+	VersionRequest
+	VersionResponse
 	UndefinedRequestOrResponse
 	LastKind
 )
@@ -116,6 +118,8 @@ func init() {
 	messageKindNameByID[BlockchainIsPayableResponse] = "BlockchainIsPayableResponse"
 	messageKindNameByID[DiagnoseWaitRequest] = "DiagnoseWaitRequest"
 	messageKindNameByID[DiagnoseWaitResponse] = "DiagnoseWaitResponse"
+	messageKindNameByID[VersionRequest] = "VersionRequest"
+	messageKindNameByID[VersionResponse] = "VersionResponse"
 	messageKindNameByID[UndefinedRequestOrResponse] = "UndefinedRequestOrResponse"
 	messageKindNameByID[LastKind] = "LastKind"
 }
@@ -248,6 +252,10 @@ func IsHookCall(message MessageHandler) bool {
 // IsStopRequest returns whether a message is a stop request
 func IsStopRequest(message MessageHandler) bool {
 	return message.GetKind() == Stop
+}
+
+func IsVersionResponse(message MessageHandler) bool {
+	return message.GetKind() == VersionResponse
 }
 
 // IsContractResponse returns whether a message is a contract response

--- a/ipc/common/messagesContracts.go
+++ b/ipc/common/messagesContracts.go
@@ -4,13 +4,13 @@ import (
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
-// MessageContractDeployRequest is deploy request message (from Node)
+// MessageContractDeployRequest is a deploy request message (from the Node)
 type MessageContractDeployRequest struct {
 	Message
 	CreateInput *vmcommon.ContractCreateInput
 }
 
-// NewMessageContractDeployRequest creates a message
+// NewMessageContractDeployRequest creates a MessageContractDeployRequest
 func NewMessageContractDeployRequest(input *vmcommon.ContractCreateInput) *MessageContractDeployRequest {
 	message := &MessageContractDeployRequest{}
 	message.Kind = ContractDeployRequest
@@ -18,13 +18,13 @@ func NewMessageContractDeployRequest(input *vmcommon.ContractCreateInput) *Messa
 	return message
 }
 
-// MessageContractCallRequest is call request message (from Node)
+// MessageContractCallRequest is a call request message (from the Node)
 type MessageContractCallRequest struct {
 	Message
 	CallInput *vmcommon.ContractCallInput
 }
 
-// NewMessageContractCallRequest creates a message
+// NewMessageContractCallRequest creates a MessageContractCallRequest
 func NewMessageContractCallRequest(input *vmcommon.ContractCallInput) *MessageContractCallRequest {
 	message := &MessageContractCallRequest{}
 	message.Kind = ContractCallRequest
@@ -38,11 +38,37 @@ type MessageContractResponse struct {
 	SerializableVMOutput *SerializableVMOutput
 }
 
-// NewMessageContractResponse creates a message
+// NewMessageContractResponse creates a MessageContractResponse
 func NewMessageContractResponse(vmOutput *vmcommon.VMOutput, err error) *MessageContractResponse {
 	message := &MessageContractResponse{}
 	message.Kind = ContractResponse
 	message.SerializableVMOutput = NewSerializableVMOutput(vmOutput)
 	message.SetError(err)
+	return message
+}
+
+// MessageVersionRequest is a version request message (from the Node)
+type MessageVersionRequest struct {
+	Message
+}
+
+// NewMessageVersionRequest creates a MessageVersionRequest
+func NewMessageVersionRequest() *MessageVersionRequest {
+	message := &MessageVersionRequest{}
+	message.Kind = VersionRequest
+	return message
+}
+
+// MessageVersionResponse is a version response message (from Arwen)
+type MessageVersionResponse struct {
+	Message
+	Version string
+}
+
+// NewMessageVersionResponse creates a MessageVersionResponse
+func NewMessageVersionResponse(version string) *MessageVersionResponse {
+	message := &MessageVersionResponse{}
+	message.Kind = VersionResponse
+	message.Version = version
 	return message
 }

--- a/ipc/common/messagesFactory.go
+++ b/ipc/common/messagesFactory.go
@@ -36,6 +36,8 @@ func init() {
 	messageCreators[ContractResponse] = createMessageContractResponse
 	messageCreators[DiagnoseWaitRequest] = createMessageDiagnoseWaitRequest
 	messageCreators[DiagnoseWaitResponse] = createMessageDiagnoseWaitResponse
+	messageCreators[VersionRequest] = createMessageVersionRequest
+	messageCreators[VersionResponse] = createMessageVersionResponse
 
 	messageCreators[BlockchainNewAddressRequest] = createMessageBlockchainNewAddressRequest
 	messageCreators[BlockchainNewAddressResponse] = createMessageBlockchainNewAddressResponse
@@ -109,6 +111,13 @@ func createMessageDiagnoseWaitResponse() MessageHandler {
 	return &MessageDiagnoseWaitResponse{}
 }
 
+func createMessageVersionRequest() MessageHandler {
+	return &MessageVersionRequest{}
+}
+
+func createMessageVersionResponse() MessageHandler {
+	return &MessageVersionResponse{}
+}
 func createUndefinedMessage() MessageHandler {
 	return NewUndefinedMessage()
 }

--- a/ipc/nodepart/arwenDriver.go
+++ b/ipc/nodepart/arwenDriver.go
@@ -195,6 +195,27 @@ func (driver *ArwenDriver) IsClosed() bool {
 	return err != nil
 }
 
+func (driver *ArwenDriver) GetVersion() (string, error) {
+	log.Trace("GetVersion")
+
+	err := driver.RestartArwenIfNecessary()
+	if err != nil {
+		return "", common.WrapCriticalError(err)
+	}
+
+	request := common.NewMessageVersionRequest()
+	response, err := driver.part.StartLoop(request)
+	if err != nil {
+		log.Warn("GetVersion", "err", err)
+		_ = driver.Close()
+		return "", common.WrapCriticalError(err)
+	}
+
+	typedResponse := response.(*common.MessageVersionResponse)
+
+	return typedResponse.Version, nil
+}
+
 // RunSmartContractCreate sends a deploy request to Arwen and waits for the output
 func (driver *ArwenDriver) RunSmartContractCreate(input *vmcommon.ContractCreateInput) (*vmcommon.VMOutput, error) {
 	driver.counterDeploy++

--- a/ipc/nodepart/part.go
+++ b/ipc/nodepart/part.go
@@ -109,6 +109,9 @@ func (part *NodePart) doLoop() (common.MessageHandler, error) {
 			continue
 		}
 
+		if common.IsVersionResponse(message) {
+			return message, nil
+		}
 		if common.IsContractResponse(message) {
 			return message, nil
 		}

--- a/ipc/tests/arwenDriver_test.go
+++ b/ipc/tests/arwenDriver_test.go
@@ -83,6 +83,17 @@ func BenchmarkArwenDriver_RestartArwenIfNecessary(b *testing.B) {
 	}
 }
 
+func TestArwenDriver_GetVersion(t *testing.T) {
+	// This test requires `make arwen` before running, or must be run directly
+	// with `make test`
+	blockchain := &mock.BlockchainHookStub{}
+	driver := newDriver(t, blockchain)
+	version, err := driver.GetVersion()
+	require.Nil(t, err)
+	require.NotZero(t, len(version))
+	require.NotEqual(t, "undefined", version)
+}
+
 func newDriver(tb testing.TB, blockchain *mock.BlockchainHookStub) *nodepart.ArwenDriver {
 	driver, err := nodepart.NewArwenDriver(
 		blockchain,

--- a/ipc/tests/arwenPart_test.go
+++ b/ipc/tests/arwenPart_test.go
@@ -74,6 +74,7 @@ func doContractRequest(
 		}
 
 		part, err := arwenpart.NewArwenPart(
+			"testversion",
 			files.inputOfArwen,
 			files.outputOfArwen,
 			vmHostParameters,


### PR DESCRIPTION
* Change the Makefile to add the `appVersion` into the `arwen` executable
* Add IPC request / response API, so that the node can retrieve the `appVersion` through the `ArwenDriver`