### PR TITLE
Improvements 1-18

### DIFF
--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -363,8 +363,8 @@ func (context *runtimeContext) GetFunctionToCall() (wasmer.ExportedFunctionCallb
 		return function, nil
 	}
 
-	if function, ok := exports["main"]; ok {
-		return function, nil
+	if context.callFunction == arwen.CallbackDefault {
+		return nil, arwen.ErrNilCallbackFunction
 	}
 
 	return nil, arwen.ErrFuncNotFound
@@ -372,12 +372,7 @@ func (context *runtimeContext) GetFunctionToCall() (wasmer.ExportedFunctionCallb
 
 func (context *runtimeContext) GetInitFunction() wasmer.ExportedFunctionCallback {
 	exports := context.instance.Exports
-
 	if init, ok := exports[arwen.InitFunctionName]; ok {
-		return init
-	}
-
-	if init, ok := exports[arwen.InitFunctionNameEth]; ok {
 		return init
 	}
 

--- a/arwen/errors.go
+++ b/arwen/errors.go
@@ -88,3 +88,9 @@ var ErrDeploymentOverExistingAccount = errors.New("cannot deploy over existing a
 var ErrAccountNotPayable = errors.New("sending value to non payable contract")
 
 var ErrInvalidPublicKeySize = errors.New("invalid public key size")
+
+var ErrNilCallbackFunction = errors.New("nil callback function")
+
+var ErrUpgradeNotAllowed = errors.New("upgrade not allowed")
+
+var ErrNilContract = errors.New("nil contract")

--- a/arwen/host/arwen.go
+++ b/arwen/host/arwen.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen/contexts"
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen/cryptoapi"
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen/elrondapi"
-	"github.com/ElrondNetwork/arwen-wasm-vm/arwen/ethapi"
 	"github.com/ElrondNetwork/arwen-wasm-vm/config"
 	"github.com/ElrondNetwork/arwen-wasm-vm/crypto"
 	"github.com/ElrondNetwork/arwen-wasm-vm/wasmer"
@@ -75,11 +74,6 @@ func NewArwenVM(
 	}
 
 	imports, err = elrondapi.BigIntImports(imports)
-	if err != nil {
-		return nil, err
-	}
-
-	imports, err = ethapi.EthereumImports(imports)
 	if err != nil {
 		return nil, err
 	}

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -682,7 +682,12 @@ func (host *vmHost) getFunctionByCallType(callType vmcommon.CallType) (wasmer.Ex
 		}
 	}
 
-	return runtime.GetFunctionToCall()
+	function, err := runtime.GetFunctionToCall()
+	if err != nil && !customCallback {
+		return nil, arwen.ErrNilCallbackFunction
+	}
+
+	return function, nil
 }
 
 func (host *vmHost) getCurrentAsyncInfo() (*arwen.AsyncContextInfo, error) {


### PR DESCRIPTION
implemented a set of arwen tasks:

1. add support for upgrade from indirect call
2. add upgradeContract API
3. pass list of protected storage keys - already done
4. prevent deployment of SCs using asyncCall but not having callback - treated in an other way - if there is no callback function - nothing will be called, no error.
5. ensure conformity of Ethereum API - did a set of bugfixes on earlier PRs, right now ethereumAPI is not compiled anymore, we will add it back once SOLIDITY to WASM compile works.