### PR TITLE
Update gas handling to match 'master' implementation correctly

### DIFF
--- a/arwen/contexts/async.go
+++ b/arwen/contexts/async.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
-	extramath "github.com/ElrondNetwork/arwen-wasm-vm/math"
 	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
 )
 
@@ -192,37 +191,6 @@ func (context *asyncContext) deleteCallGroup(index int) {
 	context.AsyncCallGroups = groups
 }
 
-// AddCall adds the provided AsyncCall to the specified AsyncCallGroup
-func (context *asyncContext) AddCall(groupID string, call *arwen.AsyncCall) error {
-	if context.host.IsBuiltinFunctionName(call.SuccessCallback) {
-		return arwen.ErrCannotUseBuiltinAsCallback
-	}
-	if context.host.IsBuiltinFunctionName(call.ErrorCallback) {
-		return arwen.ErrCannotUseBuiltinAsCallback
-	}
-
-	group, ok := context.GetCallGroup(groupID)
-	if !ok {
-		group = arwen.NewAsyncCallGroup(groupID)
-		err := context.addCallGroup(group)
-		if err != nil {
-			return err
-		}
-	}
-
-	// TODO lock gas for callback
-
-	execMode, err := context.determineExecutionMode(call.Destination, call.Data)
-	if err != nil {
-		return err
-	}
-
-	call.ExecutionMode = execMode
-	group.AddAsyncCall(call)
-
-	return nil
-}
-
 func (context *asyncContext) isValidCallbackName(callback string) bool {
 	if callback == arwen.InitFunctionName {
 		return false
@@ -273,9 +241,47 @@ func (context *asyncContext) UpdateCurrentCallStatus() (*arwen.AsyncCall, error)
 	return call, nil
 }
 
-// PrepareLegacyAsyncCall builds an AsyncCall struct from its arguments, sets it as
-// the default async call and informs Wasmer to stop contract execution with BreakpointAsyncCall
-func (context *asyncContext) PrepareLegacyAsyncCall(address []byte, data []byte, value []byte) error {
+// RegisterAsyncCall validates the provided AsyncCall adds it to the specified
+// group (adding the AsyncCall consumes its gas entirely).
+func (context *asyncContext) RegisterAsyncCall(groupID string, call *arwen.AsyncCall) error {
+	runtime := context.host.Runtime()
+	metering := context.host.Metering()
+
+	// Lock gas only if a callback is defined (either for success or for error).
+	shouldLockGas := false
+	if call.SuccessCallback != "" {
+		err := runtime.ValidateCallbackName(call.SuccessCallback)
+		if err != nil {
+			return err
+		}
+		shouldLockGas = true
+	}
+	if call.ErrorCallback != "" {
+		err := runtime.ValidateCallbackName(call.ErrorCallback)
+		if err != nil {
+			return err
+		}
+		shouldLockGas = true
+	}
+
+	if shouldLockGas {
+		call.GasLocked = metering.ComputeGasLockedForAsync()
+	}
+
+	err := context.addAsyncCall(groupID, call)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RegisterLegacyAsyncCall builds a legacy AsyncCall from provided arguments,
+// computes the gas to lock depending on legacy configuration (non-dynamic gas
+// locking), then adds the AsyncCall to the predefined legacy
+// call group and informs Wasmer to stop contract execution with
+// BreakpointAsyncCall (adding the AsyncCall consumes its gas entirely).
+func (context *asyncContext) RegisterLegacyAsyncCall(address []byte, data []byte, value []byte) error {
 	legacyGroupID := arwen.LegacyAsyncCallGroupID
 
 	_, exists := context.GetCallGroup(legacyGroupID)
@@ -283,22 +289,22 @@ func (context *asyncContext) PrepareLegacyAsyncCall(address []byte, data []byte,
 		return arwen.ErrOnlyOneLegacyAsyncCallAllowed
 	}
 
-	gasToLock, err := context.prepareGasForLegacyAsyncCall()
+	gasToLock, err := context.computeGasLockForLegacyAsyncCall()
 	if err != nil {
 		return err
 	}
 
 	metering := context.host.Metering()
-	gas := metering.GasLeft()
+	gasLimit := metering.GasLeft() - gasToLock
 
-	err = context.AddCall(legacyGroupID, &arwen.AsyncCall{
+	err = context.addAsyncCall(legacyGroupID, &arwen.AsyncCall{
 		Status:          arwen.AsyncCallPending,
 		Destination:     address,
 		Data:            data,
 		ValueBytes:      value,
 		SuccessCallback: arwen.CallbackFunctionName,
 		ErrorCallback:   arwen.CallbackFunctionName,
-		ProvidedGas:     gas,
+		GasLimit:        gasLimit,
 		GasLocked:       gasToLock,
 	})
 	if err != nil {
@@ -306,6 +312,37 @@ func (context *asyncContext) PrepareLegacyAsyncCall(address []byte, data []byte,
 	}
 
 	context.host.Runtime().SetRuntimeBreakpointValue(arwen.BreakpointAsyncCall)
+
+	return nil
+}
+
+// addAsyncCall adds the provided AsyncCall to the specified AsyncCallGroup
+func (context *asyncContext) addAsyncCall(groupID string, call *arwen.AsyncCall) error {
+	metering := context.host.Metering()
+
+	err := metering.UseGasBounded(call.GasLocked)
+	if err != nil {
+		return err
+	}
+	err = metering.UseGasBounded(call.GasLimit)
+	if err != nil {
+		return err
+	}
+	execMode, err := context.determineExecutionMode(call.Destination, call.Data)
+	if err != nil {
+		return err
+	}
+
+	call.ExecutionMode = execMode
+	group, ok := context.GetCallGroup(groupID)
+	if !ok {
+		group = arwen.NewAsyncCallGroup(groupID)
+		err := context.addCallGroup(group)
+		if err != nil {
+			return err
+		}
+	}
+	group.AddAsyncCall(call)
 
 	return nil
 }
@@ -386,7 +423,7 @@ func (context *asyncContext) executeAsyncCall(asyncCall *arwen.AsyncCall) error 
 	return context.sendAsyncCallCrossShard(asyncCall)
 }
 
-func (context *asyncContext) prepareGasForLegacyAsyncCall() (uint64, error) {
+func (context *asyncContext) computeGasLockForLegacyAsyncCall() (uint64, error) {
 	metering := context.host.Metering()
 	err := metering.UseGasForAsyncStep()
 	if err != nil {
@@ -394,22 +431,17 @@ func (context *asyncContext) prepareGasForLegacyAsyncCall() (uint64, error) {
 	}
 
 	var shouldLockGas bool
-
 	if !context.host.IsDynamicGasLockingEnabled() {
 		// Legacy mode: static gas locking, always enabled
 		shouldLockGas = true
 	} else {
 		// Dynamic mode: lock only if callBack() exists
-		shouldLockGas = context.host.Runtime().HasCallbackMethod()
+		shouldLockGas = context.host.Runtime().HasFunction(arwen.CallbackFunctionName)
 	}
 
 	gasToLock := uint64(0)
 	if shouldLockGas {
 		gasToLock = metering.ComputeGasLockedForAsync()
-		err = metering.UseGasBounded(gasToLock)
-		if err != nil {
-			return 0, err
-		}
 	}
 
 	return gasToLock, nil
@@ -560,48 +592,9 @@ func (context *asyncContext) determineExecutionMode(destination []byte, data []b
 // be accummulated into the AsyncContext, then refunded to the original caller.
 // Redistribution of gas among calls in the same group should not be necessary.
 func (context *asyncContext) setupAsyncCallsGas() error {
-	gasLeft := context.host.Metering().GasLeft()
-	gasNeeded := uint64(0)
-	callsWithZeroGas := uint64(0)
-
-	for _, group := range context.AsyncCallGroups {
-		for _, asyncCall := range group.AsyncCalls {
-			var err error
-			gasNeeded, err = extramath.AddUint64(gasNeeded, asyncCall.ProvidedGas)
-			if err != nil {
-				return err
-			}
-
-			if gasNeeded > gasLeft {
-				return arwen.ErrNotEnoughGas
-			}
-
-			if asyncCall.ProvidedGas == 0 {
-				callsWithZeroGas++
-				continue
-			}
-
-			asyncCall.GasLimit = asyncCall.ProvidedGas
-		}
-	}
-
-	if callsWithZeroGas == 0 {
-		return nil
-	}
-
-	if gasLeft <= gasNeeded {
-		return arwen.ErrNotEnoughGas
-	}
-
-	gasShare := (gasLeft - gasNeeded) / callsWithZeroGas
-	for _, group := range context.AsyncCallGroups {
-		for _, asyncCall := range group.AsyncCalls {
-			if asyncCall.ProvidedGas == 0 {
-				asyncCall.GasLimit = gasShare
-			}
-		}
-	}
-
+	// TODO this method is already removed on a separate branch, where gas
+	// redistribution has been replaced with gas accummulation; the method is
+	// kept here only to simplify conflicts when merging;
 	return nil
 }
 

--- a/arwen/contexts/async_synchronous.go
+++ b/arwen/contexts/async_synchronous.go
@@ -33,6 +33,13 @@ func (context *asyncContext) executeSynchronousCalls() error {
 }
 
 func (context *asyncContext) executeSyncCall(asyncCall *arwen.AsyncCall) error {
+	// Briefly restore the AsyncCall GasLimit, after it was consumed in its
+	// entirety by addAsyncCall(); this is required, because ExecuteOnDestContext()
+	// must also consume the GasLimit in its entirety, before starting execution,
+	// but will restore any GasRemaining to the current instance.
+	metering := context.host.Metering()
+	metering.RestoreGas(asyncCall.GetGasLimit())
+
 	destinationCallInput, err := context.createContractCallInput(asyncCall)
 	if err != nil {
 		return err

--- a/arwen/contexts/metering.go
+++ b/arwen/contexts/metering.go
@@ -52,7 +52,7 @@ func (context *meteringContext) SetGasSchedule(gasMap config.GasScheduleMap) {
 
 // UseGas consumes the specified amount of gas on the currently running Wasmer instance.
 func (context *meteringContext) UseGas(gas uint64) {
- // TODO add unit test
+	// TODO add unit test
 	gasUsed := context.host.Runtime().GetPointsUsed()
 	if gas > math.MaxUint64-gasUsed {
 		gasUsed = math.MaxUint64

--- a/arwen/contexts/metering.go
+++ b/arwen/contexts/metering.go
@@ -1,8 +1,6 @@
 package contexts
 
 import (
-	"math"
-
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
 	"github.com/ElrondNetwork/arwen-wasm-vm/config"
 	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
@@ -52,14 +50,7 @@ func (context *meteringContext) SetGasSchedule(gasMap config.GasScheduleMap) {
 
 // UseGas consumes the specified amount of gas on the currently running Wasmer instance.
 func (context *meteringContext) UseGas(gas uint64) {
-	// TODO add unit test
-	gasUsed := context.host.Runtime().GetPointsUsed()
-	if gas > math.MaxUint64-gasUsed {
-		gasUsed = math.MaxUint64
-	} else {
-		gasUsed += gas
-	}
-
+	gasUsed := context.host.Runtime().GetPointsUsed() + gas
 	context.host.Runtime().SetPointsUsed(gasUsed)
 }
 

--- a/arwen/contexts/metering_test.go
+++ b/arwen/contexts/metering_test.go
@@ -228,7 +228,7 @@ func TestMeteringContext_AsyncCallGasLocking(t *testing.T) {
 
 	meteringContext, _ := NewMeteringContext(host, config.MakeGasMapForTests(), uint64(15000))
 
-	input.GasProvided = 1
+	input.GasProvided = 0
 	err := meteringContext.UseGasForAsyncStep()
 	require.Equal(t, arwen.ErrNotEnoughGas, err)
 

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -538,11 +538,21 @@ func (context *runtimeContext) VerifyContractCode() error {
 
 // ValidateCallbackName verifies whether the provided function name may be used as AsyncCall callback
 func (context *runtimeContext) ValidateCallbackName(callbackName string) error {
+	err := context.validator.verifyValidFunctionName(callbackName)
+	if err != nil {
+		return arwen.ErrInvalidFunctionName
+	}
 	if callbackName == arwen.InitFunctionName {
 		return arwen.ErrInvalidFunctionName
 	}
+	if context.host.IsBuiltinFunctionName(callbackName) {
+		return arwen.ErrCannotUseBuiltinAsCallback
+	}
+	if !context.HasFunction(callbackName) {
+		return arwen.ErrFuncNotFound
+	}
 
-	return context.validator.verifyValidFunctionName(callbackName)
+	return nil
 }
 
 // ELrondAPIErrorShouldFailExecution specifies whether an error in the EEI should abort contract execution.
@@ -630,8 +640,8 @@ func (context *runtimeContext) GetInitFunction() wasmer.ExportedFunctionCallback
 	return nil
 }
 
-func (context *runtimeContext) HasCallbackMethod() bool {
-	_, ok := context.instance.Exports[arwen.CallbackFunctionName]
+func (context *runtimeContext) HasFunction(functionName string) bool {
+	_, ok := context.instance.Exports[functionName]
 	return ok
 }
 

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -595,12 +595,12 @@ func createAsyncCall(context unsafe.Pointer,
 		return
 	}
 
-	err = async.AddCall(groupID, &arwen.AsyncCall{
+	err = async.RegisterAsyncCall(groupID, &arwen.AsyncCall{
 		Status:          arwen.AsyncCallPending,
 		Destination:     calledSCAddress,
 		Data:            data,
 		ValueBytes:      value,
-		ProvidedGas:     uint64(gas),
+		GasLimit:        uint64(gas),
 		SuccessCallback: string(successFunc),
 		ErrorCallback:   string(errorFunc),
 	})
@@ -784,7 +784,7 @@ func asyncCall(context unsafe.Pointer, destOffset int32, valueOffset int32, data
 		return
 	}
 
-	err = async.PrepareLegacyAsyncCall(calledSCAddress, data, value)
+	err = async.RegisterLegacyAsyncCall(calledSCAddress, data, value)
 	if errors.Is(err, arwen.ErrNotEnoughGas) {
 		runtime.SetRuntimeBreakpointValue(arwen.BreakpointOutOfGas)
 		return

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -94,7 +94,7 @@ type RuntimeContext interface {
 	GetVMType() []byte
 	Function() string
 	Arguments() [][]byte
-	HasCallbackMethod() bool
+	HasFunction(functionName string) bool
 	GetCurrentTxHash() []byte
 	GetOriginalTxHash() []byte
 	GetPrevTxHash() []byte
@@ -132,7 +132,6 @@ type AsyncContext interface {
 	StateStack
 
 	InitStateFromInput(input *vmcommon.ContractCallInput)
-	AddCall(groupID string, call *AsyncCall) error
 	HasPendingCallGroups() bool
 	IsComplete() bool
 	GetCallGroup(groupID string) (*AsyncCallGroup, bool)
@@ -146,7 +145,8 @@ type AsyncContext interface {
 	Save() error
 	Delete() error
 	Execute() error
-	PrepareLegacyAsyncCall(address []byte, data []byte, value []byte) error
+	RegisterAsyncCall(groupID string, call *AsyncCall) error
+	RegisterLegacyAsyncCall(address []byte, data []byte, value []byte) error
 	UpdateCurrentCallStatus() (*AsyncCall, error)
 }
 

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -33,7 +33,7 @@ type RuntimeContextMock struct {
 	CurrentTxHash          []byte
 	OriginalTxHash         []byte
 	PrevTxHash             []byte
-	HasCallback            bool
+	HasFunctionResult      bool
 }
 
 // InitState mocked method
@@ -296,6 +296,6 @@ func (r *RuntimeContextMock) SetCustomCallFunction(_ string) {
 }
 
 // HasCallbackMethod mocked method
-func (r *RuntimeContextMock) HasCallbackMethod() bool {
-	return r.HasCallback
+func (r *RuntimeContextMock) HasFunction(functionName string) bool {
+	return r.HasFunctionResult
 }


### PR DESCRIPTION
This PR does the following:
* Simplfies methods `async.AddCall()` and `async.PrepareLegacyAsyncCall()`;
* Ensures the gas of an AsyncCall is completely consumed when it is registered (but briefly refunded for in-shard execution only, to allow `ExecuteOnDestContext()` to work properly);
* Improves validation of callback functions when registering an AsyncCall.

These changes already assume that callback gas redistribution will be replaced with accumulated remaining callback gas (being implemented on branch `async-tests`, but paused due to hotfixes on master).
