### PR TITLE
Implement storage protection

### DIFF
--- a/arwen/common.go
+++ b/arwen/common.go
@@ -46,13 +46,16 @@ const (
 // function of a smart contract
 const CallbackFunctionName = "callBack"
 
-// TimeLockKeyPrefix is the storage key prefix used for timelock-related storage;
-// not protected by Arwen, nor by the Elrond node
-const TimeLockKeyPrefix = "timelock"
+// ProtectedStoragePrefix is the storage key prefix that will be protected by
+// Arwen explicitly, and implicitly by the Elrond node due to '@'; the
+// protection can be disabled temporarily by the StorageContext
+const ProtectedStoragePrefix = "ARWEN@"
 
-// AsyncDataPrefix is the storage key prefix used for AsyncContext-related
-// storage; protected by Arwen explicitly, and implicitly by the Elrond node due to '@'
-const AsyncDataPrefix = "asyncCalls"
+// TimeLockKeyPrefix is the storage key prefix used for timelock-related storage.
+const TimeLockKeyPrefix = ProtectedStoragePrefix + "TIMELOCK"
+
+// AsyncDataPrefix is the storage key prefix used for AsyncContext-related storage.
+const AsyncDataPrefix = ProtectedStoragePrefix + "ASYNC"
 
 // AsyncCallStatus represents the different status an async call can have
 type AsyncCallStatus uint8

--- a/arwen/contexts/storage.go
+++ b/arwen/contexts/storage.go
@@ -10,11 +10,12 @@ import (
 )
 
 type storageContext struct {
-	host                     arwen.VMHost
-	blockChainHook           vmcommon.BlockchainHook
-	address                  []byte
-	stateStack               [][]byte
-	elrondProtectedKeyPrefix []byte
+	host                          arwen.VMHost
+	blockChainHook                vmcommon.BlockchainHook
+	address                       []byte
+	stateStack                    [][]byte
+	elrondProtectedKeyPrefix      []byte
+	arwenStorageProtectionEnabled bool
 }
 
 // NewStorageContext creates a new storageContext
@@ -27,10 +28,11 @@ func NewStorageContext(
 		return nil, errors.New("elrondProtectedKeyPrefix cannot be empty")
 	}
 	context := &storageContext{
-		host:                     host,
-		blockChainHook:           blockChainHook,
-		stateStack:               make([][]byte, 0),
-		elrondProtectedKeyPrefix: elrondProtectedKeyPrefix,
+		host:                          host,
+		blockChainHook:                blockChainHook,
+		stateStack:                    make([][]byte, 0),
+		elrondProtectedKeyPrefix:      elrondProtectedKeyPrefix,
+		arwenStorageProtectionEnabled: true,
 	}
 
 	return context, nil
@@ -154,18 +156,34 @@ func (context *storageContext) GetStorageUnmetered(key []byte) []byte {
 	return context.getStorageFromAddressUnmetered(context.address, key)
 }
 
+// EnableStorageProtection will prevent writing to protected keys
+func (context *storageContext) EnableStorageProtection() {
+	context.arwenStorageProtectionEnabled = true
+}
+
+// DisableStorageProtection will prevent writing to protected keys
+func (context *storageContext) DisableStorageProtection() {
+	context.arwenStorageProtectionEnabled = false
+}
+
+func (context *storageContext) isArwenProtectedKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(arwen.ProtectedStoragePrefix))
+}
+
 func (context *storageContext) isElrondReservedKey(key []byte) bool {
 	return bytes.HasPrefix(key, context.elrondProtectedKeyPrefix)
 }
 
 // SetStorage sets the given value at the given key.
 func (context *storageContext) SetStorage(key []byte, value []byte) (arwen.StorageStatus, error) {
+	if context.host.Runtime().ReadOnly() {
+		return arwen.StorageUnchanged, nil
+	}
 	if context.isElrondReservedKey(key) {
 		return arwen.StorageUnchanged, arwen.ErrStoreElrondReservedKey
 	}
-
-	if context.host.Runtime().ReadOnly() {
-		return arwen.StorageUnchanged, nil
+	if context.isArwenProtectedKey(key) && context.arwenStorageProtectionEnabled {
+		return arwen.StorageUnchanged, arwen.ErrCannotWriteProtectedKey
 	}
 
 	metering := context.host.Metering()

--- a/arwen/contexts/storage.go
+++ b/arwen/contexts/storage.go
@@ -156,13 +156,13 @@ func (context *storageContext) GetStorageUnmetered(key []byte) []byte {
 	return context.getStorageFromAddressUnmetered(context.address, key)
 }
 
-// EnableStorageProtection will prevent writing to protected keys
-func (context *storageContext) EnableStorageProtection() {
+// enableStorageProtection will prevent writing to protected keys
+func (context *storageContext) enableStorageProtection() {
 	context.arwenStorageProtectionEnabled = true
 }
 
-// DisableStorageProtection will prevent writing to protected keys
-func (context *storageContext) DisableStorageProtection() {
+// disableStorageProtection will prevent writing to protected keys
+func (context *storageContext) disableStorageProtection() {
 	context.arwenStorageProtectionEnabled = false
 }
 
@@ -172,6 +172,13 @@ func (context *storageContext) isArwenProtectedKey(key []byte) bool {
 
 func (context *storageContext) isElrondReservedKey(key []byte) bool {
 	return bytes.HasPrefix(key, context.elrondProtectedKeyPrefix)
+}
+
+func (context *storageContext) SetProtectedStorage(key []byte, value []byte) (arwen.StorageStatus, error) {
+	context.disableStorageProtection()
+	defer context.enableStorageProtection()
+
+	return context.SetStorage(key, value)
 }
 
 // SetStorage sets the given value at the given key.

--- a/arwen/contexts/storage_test.go
+++ b/arwen/contexts/storage_test.go
@@ -232,13 +232,13 @@ func TestStorageContext_StorageProtection(t *testing.T) {
 	require.True(t, errors.Is(err, arwen.ErrCannotWriteProtectedKey))
 	require.Len(t, storageContext.GetStorageUpdates(address), 0)
 
-	storageContext.DisableStorageProtection()
+	storageContext.disableStorageProtection()
 	storageStatus, err = storageContext.SetStorage(key, value)
 	require.Nil(t, err)
 	require.Equal(t, arwen.StorageAdded, storageStatus)
 	require.Len(t, storageContext.GetStorageUpdates(address), 1)
 
-	storageContext.EnableStorageProtection()
+	storageContext.enableStorageProtection()
 	storageStatus, err = storageContext.SetStorage(key, value)
 	require.Equal(t, arwen.StorageUnchanged, storageStatus)
 	require.True(t, errors.Is(err, arwen.ErrCannotWriteProtectedKey))

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -935,7 +935,9 @@ func setStorageLock(context unsafe.Pointer, keyOffset int32, keyLength int32, lo
 
 	timeLockKey := arwen.CustomStorageKey(arwen.TimeLockKeyPrefix, key)
 	bigTimestamp := big.NewInt(0).SetInt64(lockTimestamp)
+	storage.DisableStorageProtection()
 	storageStatus, err := storage.SetStorage(timeLockKey, bigTimestamp.Bytes())
+	storage.EnableStorageProtection()
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
 	}

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -935,9 +935,7 @@ func setStorageLock(context unsafe.Pointer, keyOffset int32, keyLength int32, lo
 
 	timeLockKey := arwen.CustomStorageKey(arwen.TimeLockKeyPrefix, key)
 	bigTimestamp := big.NewInt(0).SetInt64(lockTimestamp)
-	storage.DisableStorageProtection()
-	storageStatus, err := storage.SetStorage(timeLockKey, bigTimestamp.Bytes())
-	storage.EnableStorageProtection()
+	storageStatus, err := storage.SetProtectedStorage(timeLockKey, bigTimestamp.Bytes())
 	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
 		return -1
 	}

--- a/arwen/errors.go
+++ b/arwen/errors.go
@@ -92,6 +92,9 @@ var ErrMaxInstancesReached = fmt.Errorf("%w (max instances reached)", ErrExecuti
 // ErrStoreElrondReservedKey signals that an attempt to write under an reserved key has been made
 var ErrStoreElrondReservedKey = errors.New("cannot write to storage under Elrond reserved key")
 
+// ErrCannotWriteProtectedKey signals an attempt to write to a protected key, while storage protection is enforced
+var ErrCannotWriteProtectedKey = errors.New("cannot write to protected key")
+
 // ErrArgIndexOutOfRange signals that the argument index is out of range
 var ErrArgIndexOutOfRange = errors.New("argument index out of range")
 

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -439,9 +439,7 @@ func (host *vmHost) savePendingAsyncCalls(pendingAsyncMap *arwen.AsyncContextInf
 		return err
 	}
 
-	storage.DisableStorageProtection()
-	_, err = storage.SetStorage(asyncCallStorageKey, data)
-	storage.EnableStorageProtection()
+	_, err = storage.SetProtectedStorage(asyncCallStorageKey, data)
 	if err != nil {
 		return err
 	}
@@ -572,10 +570,7 @@ func (host *vmHost) processCallbackStack() error {
 		return nil
 	}
 
-	storage.DisableStorageProtection()
-	_, err = storage.SetStorage(storageKey, nil)
-	storage.EnableStorageProtection()
-
+	_, err = storage.SetProtectedStorage(storageKey, nil)
 	if err != nil {
 		return err
 	}

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -439,7 +439,9 @@ func (host *vmHost) savePendingAsyncCalls(pendingAsyncMap *arwen.AsyncContextInf
 		return err
 	}
 
+	storage.DisableStorageProtection()
 	_, err = storage.SetStorage(asyncCallStorageKey, data)
+	storage.EnableStorageProtection()
 	if err != nil {
 		return err
 	}
@@ -570,7 +572,10 @@ func (host *vmHost) processCallbackStack() error {
 		return nil
 	}
 
+	storage.DisableStorageProtection()
 	_, err = storage.SetStorage(storageKey, nil)
+	storage.EnableStorageProtection()
+
 	if err != nil {
 		return err
 	}

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -209,14 +209,13 @@ const (
 type StorageContext interface {
 	StateStack
 
-	EnableStorageProtection()
-	DisableStorageProtection()
 	SetAddress(address []byte)
 	GetStorageUpdates(address []byte) map[string]*vmcommon.StorageUpdate
 	GetStorageFromAddress(address []byte, key []byte) []byte
 	GetStorage(key []byte) []byte
 	GetStorageUnmetered(key []byte) []byte
 	SetStorage(key []byte, value []byte) (StorageStatus, error)
+	SetProtectedStorage(key []byte, value []byte) (StorageStatus, error)
 }
 
 // AsyncCallInfoHandler defines the functionality for working with AsyncCallInfo

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -209,6 +209,8 @@ const (
 type StorageContext interface {
 	StateStack
 
+	EnableStorageProtection()
+	DisableStorageProtection()
 	SetAddress(address []byte)
 	GetStorageUpdates(address []byte) map[string]*vmcommon.StorageUpdate
 	GetStorageFromAddress(address []byte, key []byte) []byte


### PR DESCRIPTION
This PR defines the key prefix `ARWEN@` which will be write-protected by the `StorageContext`. 

However, the VM may allow writing to protected keys using the new methods `storage.DisableStorageProtection()` and `storage.EnableStorageProtection()`. This is required for the Promises API and the Timelocks API, which must write to protected storage.

This form of storage protection is only enforced in the VM. The Elrond node always allows `StorageUpdates` to the keys that are otherwise protected by Arwen.