### PR TITLE
Compute GasUsed in the MeteringContext

### DIFF
--- a/arwen/contexts/instanceBuilder.go
+++ b/arwen/contexts/instanceBuilder.go
@@ -1,0 +1,22 @@
+package contexts
+
+import (
+	"github.com/ElrondNetwork/arwen-wasm-vm/wasmer"
+)
+
+type wasmerInstanceBuilder struct {
+}
+
+func (builder *wasmerInstanceBuilder) NewInstanceWithOptions(
+	contractCode []byte,
+	options wasmer.CompilationOptions,
+) (*wasmer.Instance, error) {
+	return wasmer.NewInstanceWithOptions(contractCode, options)
+}
+
+func (builder *wasmerInstanceBuilder) NewInstanceFromCompiledCodeWithOptions(
+	compiledCode []byte,
+	options wasmer.CompilationOptions,
+) (*wasmer.Instance, error) {
+	return wasmer.NewInstanceFromCompiledCodeWithOptions(compiledCode, options)
+}

--- a/arwen/contexts/metering.go
+++ b/arwen/contexts/metering.go
@@ -40,11 +40,13 @@ func NewMeteringContext(
 	return context, nil
 }
 
+// InitState resets the internal state of the MeteringContext
 func (context *meteringContext) InitState() {
 	context.initialGasProvided = 0
 	context.gasForwarded = 0
 }
 
+// PushState pushes the current state of the MeteringContext on its internal state stack
 func (context *meteringContext) PushState() {
 	newState := &meteringContext{
 		initialGasProvided: context.initialGasProvided,
@@ -54,6 +56,8 @@ func (context *meteringContext) PushState() {
 	context.stateStack = append(context.stateStack, newState)
 }
 
+// PopSetActiveState pops the state at the top of the internal state stack, and
+// sets it as the current state
 func (context *meteringContext) PopSetActiveState() {
 	stateStackLen := len(context.stateStack)
 	if stateStackLen == 0 {
@@ -67,6 +71,7 @@ func (context *meteringContext) PopSetActiveState() {
 	context.gasForwarded = prevState.gasForwarded
 }
 
+// PopDiscard pops the state at the top of the internal state stack, and discards it
 func (context *meteringContext) PopDiscard() {
 	stateStackLen := len(context.stateStack)
 	if stateStackLen == 0 {
@@ -76,10 +81,13 @@ func (context *meteringContext) PopDiscard() {
 	context.stateStack = context.stateStack[:stateStackLen-1]
 }
 
+// ClearStateStack reinitializes the internal state stack to an empty stack
 func (context *meteringContext) ClearStateStack() {
 	context.stateStack = make([]*meteringContext, 0)
 }
 
+// InitStateFromContractCallInput initializes the internal state of the
+// MeteringContext using values taken from the provided ContractCallInput
 func (context *meteringContext) InitStateFromContractCallInput(input *vmcommon.ContractCallInput) {
 	context.unlockGasIfAsyncCallback(input)
 	context.initialGasProvided = input.GasProvided

--- a/arwen/host/arwen.go
+++ b/arwen/host/arwen.go
@@ -240,6 +240,7 @@ func (host *vmHost) initContexts() {
 	host.ClearContextStateStack()
 	host.bigIntContext.InitState()
 	host.outputContext.InitState()
+	host.meteringContext.InitState()
 	host.runtimeContext.InitState()
 	host.storageContext.InitState()
 	host.ethInput = nil
@@ -249,6 +250,7 @@ func (host *vmHost) initContexts() {
 func (host *vmHost) ClearContextStateStack() {
 	host.bigIntContext.ClearStateStack()
 	host.outputContext.ClearStateStack()
+	host.meteringContext.ClearStateStack()
 	host.runtimeContext.ClearStateStack()
 	host.storageContext.ClearStateStack()
 }

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -135,7 +135,9 @@ func (host *vmHost) sendAsyncCallToDestination(asyncCallInfo arwen.AsyncCallInfo
 	}
 
 	metering := host.Metering()
-	metering.UseGas(metering.GasLeft())
+	gasLeft := metering.GasLeft()
+	metering.ForwardGas(gasLeft)
+	metering.UseGas(gasLeft)
 	return nil
 }
 
@@ -166,7 +168,9 @@ func (host *vmHost) sendCallbackToCurrentCaller() error {
 		return err
 	}
 
-	metering.UseGas(metering.GasLeft())
+	gasLeft := metering.GasLeft()
+	metering.ForwardGas(gasLeft)
+	metering.UseGas(gasLeft)
 	return nil
 }
 

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
-	"github.com/ElrondNetwork/arwen-wasm-vm/arwen/contexts"
 	"github.com/ElrondNetwork/arwen-wasm-vm/math"
 	"github.com/ElrondNetwork/elrond-go-logger/check"
 	"github.com/ElrondNetwork/elrond-go/core"
@@ -42,6 +41,7 @@ func (host *vmHost) doRunSmartContractCreate(input *vmcommon.ContractCreateInput
 	if err != nil {
 		return output.CreateVMOutputInCaseOfError(err)
 	}
+
 	return vmOutput
 }
 
@@ -81,9 +81,10 @@ func (host *vmHost) doRunSmartContractUpgrade(input *vmcommon.ContractCallInput)
 	host.InitState()
 	defer host.Clean()
 
-	_, _, _, output, runtime, storage := host.GetContexts()
+	_, _, metering, output, runtime, storage := host.GetContexts()
 
 	runtime.InitStateFromContractCallInput(input)
+	metering.InitStateFromContractCallInput(input)
 	output.AddTxValueToAccount(input.RecipientAddr, input.CallValue)
 	storage.SetAddress(runtime.GetSCAddress())
 
@@ -113,6 +114,7 @@ func (host *vmHost) doRunSmartContractCall(input *vmcommon.ContractCallInput) (v
 	_, _, metering, output, runtime, storage := host.GetContexts()
 
 	runtime.InitStateFromContractCallInput(input)
+	metering.InitStateFromContractCallInput(input)
 	output.AddTxValueToAccount(input.RecipientAddr, input.CallValue)
 	storage.SetAddress(runtime.GetSCAddress())
 
@@ -121,7 +123,6 @@ func (host *vmHost) doRunSmartContractCall(input *vmcommon.ContractCallInput) (v
 		return output.CreateVMOutputInCaseOfError(arwen.ErrContractNotFound)
 	}
 
-	metering.UnlockGasIfAsyncCallback()
 	err = metering.DeductInitialGasForExecution(contract)
 	if err != nil {
 		return output.CreateVMOutputInCaseOfError(arwen.ErrNotEnoughGas)
@@ -148,24 +149,25 @@ func (host *vmHost) doRunSmartContractCall(input *vmcommon.ContractCallInput) (v
 func (host *vmHost) ExecuteOnDestContext(input *vmcommon.ContractCallInput) (vmOutput *vmcommon.VMOutput, asyncInfo *arwen.AsyncContextInfo, err error) {
 	log.Trace("ExecuteOnDestContext", "function", input.Function)
 
-	bigInt, _, _, output, runtime, storage := host.GetContexts()
+	bigInt, _, metering, output, runtime, storage := host.GetContexts()
 
 	bigInt.PushState()
 	bigInt.InitState()
 
 	output.PushState()
 	output.CensorVMOutput()
-	output.ResetGas()
 
 	runtime.PushState()
 	runtime.InitStateFromContractCallInput(input)
 
+	metering.PushState()
+	metering.InitStateFromContractCallInput(input)
+
 	storage.PushState()
 	storage.SetAddress(runtime.GetSCAddress())
 
-	gasUsed := uint64(0)
 	defer func() {
-		vmOutput = host.finishExecuteOnDestContext(gasUsed, err)
+		vmOutput = host.finishExecuteOnDestContext(err)
 	}()
 
 	// Perform a value transfer to the called SC. If the execution fails, this
@@ -175,7 +177,7 @@ func (host *vmHost) ExecuteOnDestContext(input *vmcommon.ContractCallInput) (vmO
 		return
 	}
 
-	gasUsed, err = host.execute(input)
+	err = host.execute(input)
 	if err != nil {
 		return
 	}
@@ -185,56 +187,20 @@ func (host *vmHost) ExecuteOnDestContext(input *vmcommon.ContractCallInput) (vmO
 	return
 }
 
-// computeGasUsedByCurrentSC isolates the gas that was exclusively used for
-// contract execution, subtracting any gas that was sent to other contracts as
-// GasLimit for asynchronous calls, or any GasLocked for asynchronous callbacks.
-// TODO move this into the OutputContext
-func computeGasUsedByCurrentSC(
-	gasUsed uint64,
-	output arwen.OutputContext,
-	executeErr error,
-) (uint64, error) {
-	if executeErr != nil {
-		return 0, executeErr
-	}
-
-	vmOutput := output.GetVMOutput()
-	if vmOutput.ReturnCode != vmcommon.Ok || gasUsed == 0 {
-		return 0, nil
-	}
-
-	for _, outAcc := range vmOutput.OutputAccounts {
-		accumulatedGasLimitsAndGasLocks := uint64(0)
-		for _, outTransfer := range outAcc.OutputTransfers {
-			accumulatedGasLimitsAndGasLocks = math.AddUint64(accumulatedGasLimitsAndGasLocks, outTransfer.GasLimit)
-			accumulatedGasLimitsAndGasLocks = math.AddUint64(accumulatedGasLimitsAndGasLocks, outTransfer.GasLocked)
-		}
-
-		if gasUsed < math.AddUint64(outAcc.GasUsed, accumulatedGasLimitsAndGasLocks) {
-			return 0, arwen.ErrGasUsageError
-		}
-
-		gasUsed -= outAcc.GasUsed
-		gasUsed -= accumulatedGasLimitsAndGasLocks
-	}
-
-	return gasUsed, nil
-}
-
-func (host *vmHost) finishExecuteOnDestContext(gasUsed uint64, executeErr error) *vmcommon.VMOutput {
+func (host *vmHost) finishExecuteOnDestContext(executeErr error) *vmcommon.VMOutput {
 	bigInt, _, metering, output, runtime, storage := host.GetContexts()
 
 	// Extract the VMOutput produced by the execution in isolation, before
 	// restoring the contexts. This needs to be done before popping any state
 	// stacks.
-	gasUsedBySC, err := computeGasUsedByCurrentSC(gasUsed, output, executeErr)
-	if err != nil {
+	if executeErr != nil {
 		// Execution failed: restore contexts as if the execution didn't happen,
 		// but first create a vmOutput to capture the error.
-		vmOutput := output.CreateVMOutputInCaseOfError(err)
+		vmOutput := output.CreateVMOutputInCaseOfError(executeErr)
 
 		bigInt.PopSetActiveState()
 		output.PopSetActiveState()
+		metering.PopSetActiveState()
 		runtime.PopSetActiveState()
 		storage.PopSetActiveState()
 
@@ -244,21 +210,22 @@ func (host *vmHost) finishExecuteOnDestContext(gasUsed uint64, executeErr error)
 	// Retrieve the VMOutput before popping the Runtime state and the previous
 	// instance, to ensure accurate GasRemaining
 	vmOutput := output.GetVMOutput()
+	gasUsedByContract := metering.GasUsedByContract()
 
 	// Restore the previous context states, except Output, which will be merged
 	// into the initial state (VMOutput), but only if it the child execution
 	// returned vmcommon.Ok.
 	bigInt.PopSetActiveState()
+	metering.PopSetActiveState()
 	runtime.PopSetActiveState()
 	storage.PopSetActiveState()
 
 	// Restore remaining gas to the caller Wasmer instance
 	metering.RestoreGas(vmOutput.GasRemaining)
+	metering.ForwardGas(gasUsedByContract)
 
 	if vmOutput.ReturnCode == vmcommon.Ok {
 		output.PopMergeActiveState()
-		scAddress := string(runtime.GetSCAddress())
-		accumulateGasUsedByContract(vmOutput, scAddress, gasUsedBySC)
 	} else {
 		output.PopSetActiveState()
 	}
@@ -275,7 +242,7 @@ func (host *vmHost) ExecuteOnSameContext(input *vmcommon.ContractCallInput) (asy
 		return nil, arwen.ErrBuiltinCallOnSameContextDisallowed
 	}
 
-	bigInt, _, _, output, runtime, _ := host.GetContexts()
+	bigInt, _, metering, output, runtime, _ := host.GetContexts()
 
 	// Back up the states of the contexts (except Storage, which isn't affected
 	// by ExecuteOnSameContext())
@@ -283,12 +250,13 @@ func (host *vmHost) ExecuteOnSameContext(input *vmcommon.ContractCallInput) (asy
 	output.PushState()
 	runtime.PushState()
 
-	output.ResetGas()
 	runtime.InitStateFromContractCallInput(input)
 
-	gasUsed := uint64(0)
+	metering.PushState()
+	metering.InitStateFromContractCallInput(input)
+
 	defer func() {
-		host.finishExecuteOnSameContext(gasUsed, err)
+		host.finishExecuteOnSameContext(err)
 	}()
 
 	// Perform a value transfer to the called SC. If the execution fails, this
@@ -298,7 +266,7 @@ func (host *vmHost) ExecuteOnSameContext(input *vmcommon.ContractCallInput) (asy
 		return
 	}
 
-	gasUsed, err = host.execute(input)
+	err = host.execute(input)
 	if err != nil {
 		return
 	}
@@ -307,13 +275,13 @@ func (host *vmHost) ExecuteOnSameContext(input *vmcommon.ContractCallInput) (asy
 	return
 }
 
-func (host *vmHost) finishExecuteOnSameContext(gasUsed uint64, executeErr error) {
+func (host *vmHost) finishExecuteOnSameContext(executeErr error) {
 	bigInt, _, metering, output, runtime, _ := host.GetContexts()
 
-	gasUsedBySC, err := computeGasUsedByCurrentSC(gasUsed, output, executeErr)
-	if output.ReturnCode() != vmcommon.Ok || err != nil {
+	if output.ReturnCode() != vmcommon.Ok || executeErr != nil {
 		// Execution failed: restore contexts as if the execution didn't happen.
 		bigInt.PopSetActiveState()
+		metering.PopSetActiveState()
 		output.PopSetActiveState()
 		runtime.PopSetActiveState()
 
@@ -322,27 +290,19 @@ func (host *vmHost) finishExecuteOnSameContext(gasUsed uint64, executeErr error)
 
 	// Retrieve the VMOutput before popping the Runtime state and the previous
 	// instance, to ensure accurate GasRemaining
-	scAddress := string(runtime.GetSCAddress())
 	vmOutput := output.GetVMOutput()
-	accumulateGasUsedByContract(vmOutput, scAddress, gasUsedBySC)
+	gasUsedByContract := metering.GasUsedByContract()
 
 	// Execution successful: discard the backups made at the beginning and
 	// resume from the new state.
 	bigInt.PopDiscard()
 	output.PopDiscard()
+	metering.PopSetActiveState()
 	runtime.PopSetActiveState()
 
 	// Restore remaining gas to the caller Wasmer instance
 	metering.RestoreGas(vmOutput.GasRemaining)
-
-}
-
-// TODO move this into the OutputContext
-func accumulateGasUsedByContract(vmOutput *vmcommon.VMOutput, scAddress string, gasUsed uint64) {
-	if _, ok := vmOutput.OutputAccounts[scAddress]; !ok {
-		vmOutput.OutputAccounts[scAddress] = contexts.NewVMOutputAccount([]byte(scAddress))
-	}
-	vmOutput.OutputAccounts[scAddress].GasUsed += gasUsed
+	metering.ForwardGas(gasUsedByContract)
 }
 
 func (host *vmHost) isInitFunctionBeingCalled() bool {
@@ -452,18 +412,17 @@ func (host *vmHost) checkUpgradePermission(vmInput *vmcommon.ContractCallInput) 
 
 // executeUpgrade upgrades a contract indirectly (from another contract). This
 // function follows the convention of executeSmartContractCall().
-func (host *vmHost) executeUpgrade(input *vmcommon.ContractCallInput) (uint64, error) {
+func (host *vmHost) executeUpgrade(input *vmcommon.ContractCallInput) error {
 	_, _, metering, output, runtime, _ := host.GetContexts()
 
-	initialGasProvided := input.GasProvided
 	err := host.checkUpgradePermission(input)
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	code, codeMetadata, err := runtime.ExtractCodeUpgradeFromArgs()
 	if err != nil {
-		return 0, arwen.ErrInvalidUpgradeArguments
+		return arwen.ErrInvalidUpgradeArguments
 	}
 
 	codeDeployInput := arwen.CodeDeployInput{
@@ -476,7 +435,7 @@ func (host *vmHost) executeUpgrade(input *vmcommon.ContractCallInput) (uint64, e
 	err = metering.DeductInitialGasForDirectDeployment(codeDeployInput)
 	if err != nil {
 		output.SetReturnCode(vmcommon.OutOfGas)
-		return 0, err
+		return err
 	}
 
 	runtime.MustVerifyNextContractCode()
@@ -485,21 +444,20 @@ func (host *vmHost) executeUpgrade(input *vmcommon.ContractCallInput) (uint64, e
 	err = runtime.StartWasmerInstance(codeDeployInput.ContractCode, vmInput.GasProvided, true)
 	if err != nil {
 		log.Debug("performCodeDeployment/StartWasmerInstance", "err", err)
-		return 0, arwen.ErrContractInvalid
+		return arwen.ErrContractInvalid
 	}
 
 	err = host.callInitFunction()
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	output.DeployCode(codeDeployInput)
 	if output.ReturnCode() != vmcommon.Ok {
-		return 0, arwen.ErrReturnCodeNotOk
+		return arwen.ErrReturnCodeNotOk
 	}
 
-	gasToRestoreToCaller := metering.GasLeft()
-	return math.SubUint64(initialGasProvided, gasToRestoreToCaller), nil
+	return nil
 }
 
 // executeSmartContractCall executes an indirect call to a smart contract,
@@ -522,16 +480,14 @@ func (host *vmHost) executeSmartContractCall(
 	runtime arwen.RuntimeContext,
 	output arwen.OutputContext,
 	withInitialGasDeduct bool,
-) (uint64, error) {
+) error {
 	if host.isInitFunctionBeingCalled() && !input.AllowInitFunction {
-		return 0, arwen.ErrInitFuncCalledInRun
+		return arwen.ErrInitFuncCalledInRun
 	}
 
 	// Use all gas initially, on the Wasmer instance of the caller. In case of
 	// successful execution, the unused gas will be restored.
-	metering.UnlockGasIfAsyncCallback()
-	initialGasProvided := input.GasProvided
-	metering.UseGas(initialGasProvided)
+	metering.UseGas(input.GasProvided)
 
 	isUpgrade := input.Function == arwen.UpgradeFunctionName
 	if isUpgrade {
@@ -540,13 +496,13 @@ func (host *vmHost) executeSmartContractCall(
 
 	contract, err := runtime.GetSCCode()
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	if withInitialGasDeduct {
 		err = metering.DeductInitialGasForExecution(contract)
 		if err != nil {
-			return 0, err
+			return err
 		}
 	}
 
@@ -557,43 +513,43 @@ func (host *vmHost) executeSmartContractCall(
 	// before calling executeSmartContractCall().
 	err = runtime.StartWasmerInstance(contract, gasForExecution, false)
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	err = host.callSCMethodIndirect()
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	if output.ReturnCode() != vmcommon.Ok {
-		return 0, arwen.ErrReturnCodeNotOk
+		return arwen.ErrReturnCodeNotOk
 	}
 
-	gasToRestoreToCaller := metering.GasLeft()
-	return math.SubUint64(initialGasProvided, gasToRestoreToCaller), nil
+	return nil
 }
 
-func (host *vmHost) execute(input *vmcommon.ContractCallInput) (uint64, error) {
+func (host *vmHost) execute(input *vmcommon.ContractCallInput) error {
 	_, _, metering, output, runtime, storage := host.GetContexts()
 
 	if host.isBuiltinFunctionBeingCalled() {
 		err := metering.UseGasForAsyncStep()
 		if err != nil {
-			return 0, err
+			return err
 		}
 
 		newVMInput, err := host.callBuiltinFunction(input)
 		if err != nil {
-			return 0, err
+			return err
 		}
 
 		if newVMInput != nil {
 			runtime.InitStateFromContractCallInput(newVMInput)
+			metering.InitStateFromContractCallInput(newVMInput)
 			storage.SetAddress(runtime.GetSCAddress())
 			return host.executeSmartContractCall(newVMInput, metering, runtime, output, false)
 		}
 
-		return 0, nil
+		return nil
 	}
 
 	return host.executeSmartContractCall(input, metering, runtime, output, true)

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -248,8 +248,8 @@ func (host *vmHost) ExecuteOnSameContext(input *vmcommon.ContractCallInput) (asy
 	// by ExecuteOnSameContext())
 	bigInt.PushState()
 	output.PushState()
-	runtime.PushState()
 
+	runtime.PushState()
 	runtime.InitStateFromContractCallInput(input)
 
 	metering.PushState()

--- a/arwen/host/execution_test.go
+++ b/arwen/host/execution_test.go
@@ -1287,14 +1287,15 @@ func TestExecution_Mocked_Wasmer_Instances(t *testing.T) {
 	parentInstance.Exports["callChild"] = mockMethod(func() {
 		host.Output().Finish([]byte("parent returns this"))
 		host.Metering().UseGas(500)
-		host.Storage().SetStorage([]byte("parent"), []byte("parent storage"))
+		_, err := host.Storage().SetStorage([]byte("parent"), []byte("parent storage"))
+		require.Nil(t, err)
 		childInput := DefaultTestContractCallInput()
 		childInput.CallerAddr = parentAddress
 		childInput.RecipientAddr = childAddress
 		childInput.CallValue = big.NewInt(4)
 		childInput.Function = "doSomething"
 		childInput.GasProvided = 1000
-		_, _, err := host.ExecuteOnDestContext(childInput)
+		_, _, err = host.ExecuteOnDestContext(childInput)
 		require.Nil(t, err)
 	})
 
@@ -1302,7 +1303,8 @@ func TestExecution_Mocked_Wasmer_Instances(t *testing.T) {
 	childInstance.Exports["doSomething"] = mockMethod(func() {
 		host.Output().Finish([]byte("child returns this"))
 		host.Metering().UseGas(100)
-		host.Storage().SetStorage([]byte("child"), []byte("child storage"))
+		_, err := host.Storage().SetStorage([]byte("child"), []byte("child storage"))
+		require.Nil(t, err)
 	})
 
 	input := DefaultTestContractCallInput()

--- a/arwen/host/execution_vmoutputs_test.go
+++ b/arwen/host/execution_vmoutputs_test.go
@@ -54,6 +54,7 @@ func expectedVMOutputSameCtxPrepare(_ []byte) *vmcommon.VMOutput {
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.GasUsed = 3404
 
 	_ = AddNewOutputAccount(
 		vmOutput,
@@ -155,6 +156,7 @@ func expectedVMOutputSameCtxSimple(parentCode []byte, childCode []byte) *vmcommo
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.GasUsed = 3954
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -183,6 +185,7 @@ func expectedVMOutputSameCtxSuccessfulChildCall(parentCode []byte, _ []byte) *vm
 
 	parentAccount := vmOutput.OutputAccounts[string(parentAddress)]
 	parentAccount.BalanceDelta = big.NewInt(-141)
+	parentAccount.GasUsed = 3611
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -246,7 +249,7 @@ func expectedVMOutputSameCtxSuccessfulChildCallBigInts(_ []byte, _ []byte) *vmco
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	// parentAccount.BalanceDelta = big.NewInt(-99)
+	parentAccount.GasUsed = 3460
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -288,7 +291,7 @@ func expectedVMOutputSameCtxRecursiveDirect(_ []byte, recursiveCalls int) *vmcom
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
-	account.GasUsed = 21187
+	account.GasUsed = 50812
 
 	for i := recursiveCalls; i >= 0; i-- {
 		finishString := fmt.Sprintf("Rfinish%03d", i)
@@ -345,7 +348,7 @@ func expectedVMOutputSameCtxRecursiveMutualMethods(_ []byte, recursiveCalls int)
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
-	account.GasUsed = 25412
+	account.GasUsed = 67668
 
 	SetStorageUpdate(account, recursiveIterationCounterKey, []byte{byte(recursiveCalls + 1)})
 	SetStorageUpdate(account, recursiveIterationBigCounterKey, big.NewInt(int64(recursiveCalls+1)).Bytes())
@@ -389,7 +392,7 @@ func expectedVMOutputSameCtxRecursiveMutualSCs(_ []byte, _ []byte, recursiveCall
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
-	parentAccount.GasUsed = 3650
+	parentAccount.GasUsed = 10936
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -398,7 +401,7 @@ func expectedVMOutputSameCtxRecursiveMutualSCs(_ []byte, _ []byte, recursiveCall
 		nil,
 	)
 	childAccount.Balance = big.NewInt(1000)
-	childAccount.GasUsed = 5437
+	childAccount.GasUsed = 10836
 
 	if recursiveCalls%2 == 1 {
 		parentAccount.BalanceDelta = big.NewInt(-5)
@@ -501,6 +504,7 @@ func expectedVMOutputDestCtxPrepare(_ []byte) *vmcommon.VMOutput {
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.GasUsed = 3092
 
 	_ = AddNewOutputAccount(
 		vmOutput,
@@ -586,6 +590,7 @@ func expectedVMOutputDestCtxSuccessfulChildCall(parentCode []byte, _ []byte) *vm
 
 	parentAccount := vmOutput.OutputAccounts[string(parentAddress)]
 	parentAccount.BalanceDelta = big.NewInt(-141)
+	parentAccount.GasUsed = 3227
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -594,6 +599,7 @@ func expectedVMOutputDestCtxSuccessfulChildCall(parentCode []byte, _ []byte) *vm
 		nil,
 	)
 	childAccount.Balance = big.NewInt(1000)
+	childAccount.GasUsed = 2255
 
 	_ = AddNewOutputAccount(
 		vmOutput,
@@ -634,13 +640,15 @@ func expectedVMOutputDestCtxSuccessfulChildCallBigInts(_ []byte, _ []byte) *vmco
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.GasUsed = 3149
 
-	_ = AddNewOutputAccount(
+	childAccount := AddNewOutputAccount(
 		vmOutput,
 		childAddress,
 		99,
 		nil,
 	)
+	childAccount.GasUsed = 2264
 
 	// The child SC will output "child ok" if it could NOT read the Big Ints from
 	// the parent's context.
@@ -674,6 +682,7 @@ func expectedVMOutputDestCtxRecursiveDirect(_ []byte, recursiveCalls int) *vmcom
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
+	account.GasUsed = 67754
 
 	for i := recursiveCalls; i >= 0; i-- {
 		finishString := fmt.Sprintf("Rfinish%03d", i)
@@ -707,6 +716,7 @@ func expectedVMOutputDestCtxRecursiveMutualMethods(_ []byte, recursiveCalls int)
 	)
 	account.Balance = big.NewInt(1000)
 	account.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
+	account.GasUsed = 105826
 
 	SetStorageUpdate(account, recursiveIterationCounterKey, []byte{byte(recursiveCalls + 1)})
 	SetStorageUpdate(account, recursiveIterationBigCounterKey, big.NewInt(int64(1)).Bytes())
@@ -756,6 +766,7 @@ func expectedVMOutputDestCtxRecursiveMutualSCs(_ []byte, _ []byte, recursiveCall
 	)
 	parentAccount.Balance = big.NewInt(1000)
 	parentAccount.BalanceDelta = big.NewInt(-balanceDelta)
+	parentAccount.GasUsed = 18084
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -765,6 +776,7 @@ func expectedVMOutputDestCtxRecursiveMutualSCs(_ []byte, _ []byte, recursiveCall
 	)
 	childAccount.Balance = big.NewInt(1000)
 	childAccount.BalanceDelta = big.NewInt(balanceDelta)
+	childAccount.GasUsed = 10936
 
 	for i := 0; i <= recursiveCalls; i++ {
 		var finishData string
@@ -811,6 +823,7 @@ func expectedVMOutputDestCtxByCallerSimpleTransfer(value int64) *vmcommon.VMOutp
 		nil,
 	)
 	parentAccount.Balance = nil
+	parentAccount.GasUsed = 761
 
 	childAccount := AddNewOutputAccount(
 		vmOutput,
@@ -820,6 +833,7 @@ func expectedVMOutputDestCtxByCallerSimpleTransfer(value int64) *vmcommon.VMOutp
 	)
 	childAccount.Balance = big.NewInt(1000)
 	childAccount.BalanceDelta = big.NewInt(-value)
+	childAccount.GasUsed = 666
 
 	userAccount := AddNewOutputAccount(
 		vmOutput,
@@ -851,6 +865,7 @@ func expectedVMOutputAsyncCall(_ []byte, _ []byte) *vmcommon.VMOutput {
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.GasUsed = 106047
 	SetStorageUpdate(parentAccount, parentKeyA, parentDataA)
 	SetStorageUpdate(parentAccount, parentKeyB, parentDataB)
 	AddFinishData(vmOutput, parentFinishA)
@@ -873,6 +888,7 @@ func expectedVMOutputAsyncCall(_ []byte, _ []byte) *vmcommon.VMOutput {
 		nil,
 	)
 	childAccount.Balance = big.NewInt(1000)
+	childAccount.GasUsed = 1295
 	SetStorageUpdate(childAccount, childKey, childData)
 
 	_ = AddNewOutputAccount(
@@ -901,6 +917,7 @@ func expectedVMOutputAsyncCallChildFails(_ []byte, _ []byte) *vmcommon.VMOutput 
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.GasUsed = 1002048
 	SetStorageUpdate(parentAccount, parentKeyA, parentDataA)
 	SetStorageUpdate(parentAccount, parentKeyB, parentDataB)
 	AddFinishData(vmOutput, parentFinishA)
@@ -943,6 +960,7 @@ func expectedVMOutputAsyncCallCallBackFails(_ []byte, _ []byte) *vmcommon.VMOutp
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.GasUsed = 2098677
 	SetStorageUpdate(parentAccount, parentKeyA, parentDataA)
 	SetStorageUpdate(parentAccount, parentKeyB, parentDataB)
 	AddFinishData(vmOutput, parentFinishA)
@@ -967,6 +985,7 @@ func expectedVMOutputAsyncCallCallBackFails(_ []byte, _ []byte) *vmcommon.VMOutp
 	)
 	childAccount.Balance = big.NewInt(1000)
 	childAccount.BalanceDelta = big.NewInt(0).Sub(big.NewInt(1), big.NewInt(1))
+	childAccount.GasUsed = 1295
 	SetStorageUpdate(childAccount, childKey, childData)
 
 	_ = AddNewOutputAccount(
@@ -996,6 +1015,7 @@ func expectedVMOutputCreateNewContractSuccess(_ []byte, childCode []byte) *vmcom
 		nil,
 	)
 	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.GasUsed = 6536
 	parentAccount.Nonce = 1
 	SetStorageUpdate(parentAccount, []byte{'A'}, childCode)
 
@@ -1006,6 +1026,7 @@ func expectedVMOutputCreateNewContractSuccess(_ []byte, childCode []byte) *vmcom
 		nil,
 	)
 	childAccount.Code = childCode
+	childAccount.GasUsed = 471
 	childAccount.CodeMetadata = []byte{1, 0}
 	childAccount.CodeDeployerAddress = parentAddress
 
@@ -1026,6 +1047,7 @@ func expectedVMOutputCreateNewContractFail(_ []byte, childCode []byte) *vmcommon
 		nil,
 	)
 	parentAccount.Nonce = 0
+	parentAccount.GasUsed = 8536
 	SetStorageUpdate(parentAccount, []byte{'A'}, childCode)
 
 	l := len(childCode)
@@ -1046,6 +1068,7 @@ func expectedVMOutputMockedWasmerInstances() *vmcommon.VMOutput {
 	)
 	parentAccount.Balance = big.NewInt(1000)
 	parentAccount.BalanceDelta = big.NewInt(-4)
+	parentAccount.GasUsed = 546
 	SetStorageUpdate(parentAccount, []byte("parent"), []byte("parent storage"))
 
 	childAccount := AddNewOutputAccount(
@@ -1055,6 +1078,7 @@ func expectedVMOutputMockedWasmerInstances() *vmcommon.VMOutput {
 		nil,
 	)
 	childAccount.BalanceDelta = big.NewInt(4)
+	childAccount.GasUsed = 145
 	SetStorageUpdate(childAccount, []byte("child"), []byte("child storage"))
 
 	AddFinishData(vmOutput, []byte("parent returns this"))

--- a/arwen/host/execution_vmoutputs_test.go
+++ b/arwen/host/execution_vmoutputs_test.go
@@ -1034,3 +1034,31 @@ func expectedVMOutputCreateNewContractFail(_ []byte, childCode []byte) *vmcommon
 
 	return vmOutput
 }
+
+func expectedVMOutputMockedWasmerInstances() *vmcommon.VMOutput {
+	vmOutput := MakeVMOutput()
+
+	parentAccount := AddNewOutputAccount(
+		vmOutput,
+		parentAddress,
+		0,
+		nil,
+	)
+	parentAccount.Balance = big.NewInt(1000)
+	parentAccount.BalanceDelta = big.NewInt(-4)
+	SetStorageUpdate(parentAccount, []byte("parent"), []byte("parent storage"))
+
+	childAccount := AddNewOutputAccount(
+		vmOutput,
+		childAddress,
+		0,
+		nil,
+	)
+	childAccount.BalanceDelta = big.NewInt(4)
+	SetStorageUpdate(childAccount, []byte("child"), []byte("child storage"))
+
+	AddFinishData(vmOutput, []byte("parent returns this"))
+	AddFinishData(vmOutput, []byte("child returns this"))
+
+	return vmOutput
+}

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -127,6 +127,10 @@ type RuntimeContext interface {
 	CryptoAPIErrorShouldFailExecution() bool
 	BigIntAPIErrorShouldFailExecution() bool
 	ExecuteAsyncCall(address []byte, data []byte, value []byte) error
+
+	// TODO remove after implementing proper mocking of Wasmer instances; this is
+	// used for tests only
+	ReplaceInstanceBuilder(builder InstanceBuilder)
 }
 
 // BigIntContext defines the functionality needed for interacting with the big int context
@@ -225,4 +229,10 @@ type AsyncCallInfoHandler interface {
 	GetGasLimit() uint64
 	GetGasLocked() uint64
 	GetValueBytes() []byte
+}
+
+// InstanceBuilder defines the functionality needed to create Wasmer instances
+type InstanceBuilder interface {
+	NewInstanceWithOptions(contractCode []byte, options wasmer.CompilationOptions) (*wasmer.Instance, error)
+	NewInstanceFromCompiledCodeWithOptions(compiledCode []byte, options wasmer.CompilationOptions) (*wasmer.Instance, error)
 }

--- a/arwen/interface.go
+++ b/arwen/interface.go
@@ -148,7 +148,6 @@ type OutputContext interface {
 	StateStack
 	PopMergeActiveState()
 	CensorVMOutput()
-	ResetGas()
 	AddToActiveState(rightOutput *vmcommon.VMOutput)
 
 	GetOutputAccount(address []byte) (*vmcommon.OutputAccount, bool)
@@ -174,12 +173,18 @@ type OutputContext interface {
 
 // MeteringContext defines the functionality needed for interacting with the metering context
 type MeteringContext interface {
+	StateStack
+
+	InitStateFromContractCallInput(input *vmcommon.ContractCallInput)
 	SetGasSchedule(gasMap config.GasScheduleMap)
 	GasSchedule() *config.GasCost
 	UseGas(gas uint64)
 	FreeGas(gas uint64)
 	RestoreGas(gas uint64)
 	GasLeft() uint64
+	GasForwarded() uint64
+	ForwardGas(gas uint64)
+	GasUsedByContract() uint64
 	BoundGasLimit(value int64) uint64
 	BlockGasLimit() uint64
 	DeductInitialGasForExecution(contract []byte) error
@@ -188,7 +193,6 @@ type MeteringContext interface {
 	ComputeGasLockedForAsync() uint64
 	UseGasForAsyncStep() error
 	UseGasBounded(gasToUse uint64) error
-	UnlockGasIfAsyncCallback()
 	GetGasLocked() uint64
 }
 

--- a/mock/context/instanceBuilderMock.go
+++ b/mock/context/instanceBuilderMock.go
@@ -1,0 +1,90 @@
+package mock
+
+import (
+	"testing"
+
+	"github.com/ElrondNetwork/arwen-wasm-vm/wasmer"
+	"github.com/stretchr/testify/require"
+)
+
+// InstanceBuilderMock can be passed to RuntimeContext as an InstanceBuilder to
+// create mocked Wasmer instances.
+type InstanceBuilderMock struct {
+	tb          testing.TB
+	InstanceMap map[string]*wasmer.Instance
+	DefaultCode []byte
+}
+
+// NewInstanceBuilderMock constructs a new InstanceBuilderMock
+func NewInstanceBuilderMock(tb testing.TB, defaultCode []byte) *InstanceBuilderMock {
+	return &InstanceBuilderMock{
+		InstanceMap: make(map[string]*wasmer.Instance),
+		DefaultCode: defaultCode,
+	}
+}
+
+// CreateAndStoreInstanceMock creates a real Wasmer instance using the
+// DefaultCode and returns it, so that a test may alter its Exports map to
+// inject new contract methods; afterwards, the RuntimeContext will call
+// NewInstanceWithOptions() and obtain the instance with the injected methods.
+//
+// It is necessary to call CreateAndStoreInstanceMock() for any contract that is
+// to be called, or at least manually populate the InstanceMap appropriately
+// (real WASM contracts may be used to populate it, as well).
+func (builder *InstanceBuilderMock) CreateAndStoreInstanceMock(code []byte) *wasmer.Instance {
+	options := wasmer.CompilationOptions{
+		GasLimit:           1000000000,
+		UnmeteredLocals:    4000,
+		OpcodeTrace:        false,
+		Metering:           true,
+		RuntimeBreakpoints: true,
+	}
+
+	instance, err := wasmer.NewInstanceWithOptions(builder.DefaultCode, options)
+	require.NotNil(builder.tb, instance)
+	require.Nil(builder.tb, err)
+	builder.InstanceMap[string(code)] = instance
+
+	return instance
+}
+
+// GetStoredInstanceMock retrieves and initializes a stored Wasmer instance, or
+// nil if it doesn't exist
+func (builder *InstanceBuilderMock) GetStoredInstanceMock(code []byte, gasLimit uint64) (*wasmer.Instance, bool) {
+	instance, ok := builder.InstanceMap[string(code)]
+	if ok {
+		instance.SetPointsUsed(0)
+		instance.SetGasLimit(gasLimit)
+		return instance, true
+	}
+	return nil, false
+}
+
+// NewInstanceWithOptions attempts to load a prepared instance using
+// GetStoredInstanceMock; if it doesn't exist, it creates a true Wasmer
+// instance with the provided contract code.
+func (builder *InstanceBuilderMock) NewInstanceWithOptions(
+	contractCode []byte,
+	options wasmer.CompilationOptions,
+) (*wasmer.Instance, error) {
+
+	instance, ok := builder.GetStoredInstanceMock(contractCode, options.GasLimit)
+	if ok {
+		return instance, nil
+	}
+	return wasmer.NewInstanceWithOptions(contractCode, options)
+}
+
+// NewInstanceWithOptions attempts to load a prepared instance using
+// GetStoredInstanceMock; if it doesn't exist, it creates a true Wasmer
+// instance with the provided precompiled code.
+func (builder *InstanceBuilderMock) NewInstanceFromCompiledCodeWithOptions(
+	compiledCode []byte,
+	options wasmer.CompilationOptions,
+) (*wasmer.Instance, error) {
+	instance, ok := builder.GetStoredInstanceMock(compiledCode, options.GasLimit)
+	if ok {
+		return instance, nil
+	}
+	return wasmer.NewInstanceFromCompiledCodeWithOptions(compiledCode, options)
+}

--- a/mock/context/meteringContextMock.go
+++ b/mock/context/meteringContextMock.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
 	"github.com/ElrondNetwork/arwen-wasm-vm/config"
+	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
 )
 
 var _ arwen.MeteringContext = (*MeteringContextMock)(nil)
@@ -15,6 +16,26 @@ type MeteringContextMock struct {
 	GasComputedToLock uint64
 	BlockGasLimitMock uint64
 	Err               error
+}
+
+// InitState mocked method
+func (m *MeteringContextMock) InitState() {
+}
+
+// PushState mocked method
+func (m *MeteringContextMock) PushState() {
+}
+
+// PopSetActiveState mocked method
+func (m *MeteringContextMock) PopSetActiveState() {
+}
+
+// PopDiscard mocked method
+func (m *MeteringContextMock) PopDiscard() {
+}
+
+// ClearStateStack mocked method
+func (m *MeteringContextMock) ClearStateStack() {
 }
 
 // SetGasSchedule mocked method
@@ -43,6 +64,24 @@ func (m *MeteringContextMock) RestoreGas(gas uint64) {
 // GasLeft mocked method
 func (m *MeteringContextMock) GasLeft() uint64 {
 	return m.GasLeftMock
+}
+
+// GasForwarded mocked method
+func (m *MeteringContextMock) GasForwarded() uint64 {
+	return 0
+}
+
+// ForwardGas mocked method
+func (m *MeteringContextMock) ForwardGas(_ uint64) {
+}
+
+// InitStateFromContractCallInput mocked method
+func (m *MeteringContextMock) InitStateFromContractCallInput(input *vmcommon.ContractCallInput) {
+}
+
+// MeteringContextMock mocked method
+func (context *MeteringContextMock) GasUsedByContract() uint64 {
+	return 0
 }
 
 // BoundGasLimit mocked method

--- a/mock/context/meteringContextMock.go
+++ b/mock/context/meteringContextMock.go
@@ -80,7 +80,7 @@ func (m *MeteringContextMock) InitStateFromContractCallInput(input *vmcommon.Con
 }
 
 // MeteringContextMock mocked method
-func (context *MeteringContextMock) GasUsedByContract() uint64 {
+func (m *MeteringContextMock) GasUsedByContract() uint64 {
 	return 0
 }
 

--- a/mock/context/outputContextMock.go
+++ b/mock/context/outputContextMock.go
@@ -86,10 +86,6 @@ func (o *OutputContextMock) CopyTopOfStackToActiveState() {
 func (o *OutputContextMock) CensorVMOutput() {
 }
 
-// ResetGas mocked method
-func (o *OutputContextMock) ResetGas() {
-}
-
 // GetOutputAccount mocked method
 func (o *OutputContextMock) GetOutputAccount(_ []byte) (*vmcommon.OutputAccount, bool) {
 	return o.OutputAccountMock, o.OutputAccountIsNew

--- a/mock/context/outputContextStub.go
+++ b/mock/context/outputContextStub.go
@@ -38,7 +38,6 @@ type OutputContextStub struct {
 	DeployCodeCalled                  func(input arwen.CodeDeployInput)
 	CreateVMOutputInCaseOfErrorCalled func(err error) *vmcommon.VMOutput
 	AddToActiveStateCalled            func(vmOutput *vmcommon.VMOutput)
-	ResetConsumedGasCalled            func()
 	TransferValueOnlyCalled           func(destination []byte, sender []byte, value *big.Int) error
 }
 
@@ -102,13 +101,6 @@ func (o *OutputContextStub) CopyTopOfStackToActiveState() {
 func (o *OutputContextStub) CensorVMOutput() {
 	if o.CensorVMOutputCalled != nil {
 		o.CensorVMOutputCalled()
-	}
-}
-
-// ResetGas mocked method
-func (o *OutputContextStub) ResetGas() {
-	if o.ResetConsumedGasCalled != nil {
-		o.ResetConsumedGasCalled()
 	}
 }
 

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -38,6 +38,10 @@ type RuntimeContextMock struct {
 func (r *RuntimeContextMock) InitState() {
 }
 
+// ReplaceInstanceBuilder mocked method()
+func (r *RuntimeContextMock) ReplaceInstanceBuilder(_ arwen.InstanceBuilder) {
+}
+
 // StartWasmerInstance mocked method
 func (r *RuntimeContextMock) StartWasmerInstance(_ []byte, _ uint64, _ bool) error {
 	if r.Err != nil {

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -50,6 +50,10 @@ func (r *RuntimeContextMock) StartWasmerInstance(_ []byte, _ uint64, _ bool) err
 	return nil
 }
 
+// SetCaching mocked method
+func (context *RuntimeContextMock) SetCaching(_ bool) {
+}
+
 // InitStateFromContractCallInput mocked method
 func (r *RuntimeContextMock) InitStateFromContractCallInput(_ *vmcommon.ContractCallInput) {
 }


### PR DESCRIPTION
This PR does the following:
* Introduces the concept of "forwarded gas", which is gas spent by a contract for the execution of **other** contracts, which means `executeOnSame/DestContext()` and `asyncCall()`; the amount of "forwarded gas" is deducted from the total gas metered for a contract, to ensure that `outputAccount.GasUsed` contains the amount used for compilation+execution exclusively, and not for other contracts, thus isolating the gas of a contract from the gas consumed by the contract for other contracts;
* Adds state stacking to the `MeteringContext`; each state item stores the initial gas provided and the gas forwarded by a contract;
* Does minor rewriting to `host.execute()`
* Adds a few tests

TODO computing `GasUsed` should have a lot more tests, but the existing ones are passing. Gas invariant checks will confirm the correctness, though.