### PR TITLE
fix-totalGas-remainingSub

### DIFF
--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -363,6 +363,7 @@ func (context *outputContext) checkGas(remainedFromForwarded uint64) error {
 
 	context.outputState.GasRemaining, remainedFromForwarded = math.SubUint64(context.outputState.GasRemaining, remainedFromForwarded)
 	totalGas := math.AddUint64(gasUsed, context.outputState.GasRemaining)
+	totalGas, _ = math.SubUint64(totalGas, remainedFromForwarded)
 	if totalGas > gasProvided {
 		log.Error("gas usage mismatch", "total gas used", totalGas, "gas provided", gasProvided)
 		return arwen.ErrInputAndOutputGasDoesNotMatch


### PR DESCRIPTION
fixing gas usage in case of claiming ESDT from a certain contract. The remaining forwarded gas should be retracted from the totalUsedGas - as it was used in previous context, verified in previous context and will be verified in the last vm output creation