### PR TITLE
Return exit code 1 when tests fail

### DIFF
--- a/cmd/test/runner.go
+++ b/cmd/test/runner.go
@@ -35,7 +35,7 @@ func main() {
 	jsonFilePath, isDir, err := resolveArgument(os.Args[1])
 	if err != nil {
 		fmt.Println(err)
-		return
+		os.Exit(1)
 	}
 
 	// init
@@ -75,5 +75,6 @@ func main() {
 		fmt.Println("SUCCESS")
 	} else {
 		fmt.Printf("ERROR: %s\n", err.Error())
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
When the tests fail, the main function for `mandos-test` should return 1.
Otherwise, test results are interpreted as successful, event though the logs say that the tests failed.
For example: https://github.com/ElrondNetwork/elrond-wasm-rs/pull/125/checks?check_run_id=1864733167
The logs say:
`Done. Passed: 272. Failed: 49. Skipped: 0.
ERROR: Some tests failed`
but the github action doesn't indicate a failure.
