### PR TITLE
Add `log.Trace()` calls in important places for debugging

### DIFF
--- a/arwen/contexts/metering.go
+++ b/arwen/contexts/metering.go
@@ -60,8 +60,6 @@ func (context *meteringContext) InitState() {
 	context.initialGasProvided = 0
 	context.initialCost = 0
 	context.gasForExecution = 0
-
-	logMetering.Trace("init state")
 }
 
 // PushState pushes the current state of the MeteringContext on its internal state stack
@@ -73,8 +71,6 @@ func (context *meteringContext) PushState() {
 	}
 
 	context.stateStack = append(context.stateStack, newState)
-
-	logMetering.Trace("state pushed onto stack")
 }
 
 // PopSetActiveState pops the state at the top of the internal state stack, and
@@ -91,8 +87,6 @@ func (context *meteringContext) PopSetActiveState() {
 	context.initialGasProvided = prevState.initialGasProvided
 	context.initialCost = prevState.initialCost
 	context.gasForExecution = prevState.gasForExecution
-
-	logMetering.Trace("state popped from stack (set as active state)")
 }
 
 // PopDiscard pops the state at the top of the internal state stack, and discards it
@@ -103,14 +97,11 @@ func (context *meteringContext) PopDiscard() {
 	}
 
 	context.stateStack = context.stateStack[:stateStackLen-1]
-
-	logMetering.Trace("state popped from stack (discarded)")
 }
 
 // ClearStateStack reinitializes the internal state stack to an empty stack
 func (context *meteringContext) ClearStateStack() {
 	context.stateStack = make([]*meteringContext, 0)
-	logMetering.Trace("state stack cleared")
 }
 
 // InitStateFromContractCallInput initializes the internal state of the
@@ -120,8 +111,6 @@ func (context *meteringContext) InitStateFromContractCallInput(input *vmcommon.V
 	context.initialGasProvided = input.GasProvided
 	context.gasForExecution = input.GasProvided
 	context.initialCost = 0
-
-	logMetering.Trace("init state from call input", "caller", input.CallerAddr)
 }
 
 // unlockGasIfAsyncCallback unlocks the locked gas if the call type is async callback

--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -71,7 +71,6 @@ func (context *outputContext) PushState() {
 	newState := newVMOutput()
 	mergeVMOutputs(newState, context.outputState)
 	context.stateStack = append(context.stateStack, newState)
-	logOutput.Trace("state pushed onto stack")
 }
 
 // PopSetActiveState removes the latest entry from the state stack and sets it as the current vm output
@@ -84,8 +83,6 @@ func (context *outputContext) PopSetActiveState() {
 	prevState := context.stateStack[stateStackLen-1]
 	context.stateStack = context.stateStack[:stateStackLen-1]
 	context.outputState = prevState
-
-	logOutput.Trace("state popped from stack (set as active state)")
 }
 
 // PopMergeActiveState merges the current state into the head of the stateStack,
@@ -105,8 +102,6 @@ func (context *outputContext) PopMergeActiveState() {
 	mergeVMOutputs(prevState, context.outputState)
 	context.outputState = newVMOutput()
 	mergeVMOutputs(context.outputState, prevState)
-
-	logOutput.Trace("state popped from stack (merged into active state)")
 }
 
 // PopDiscard removes the latest entry from the state stack, but maintaining
@@ -118,14 +113,11 @@ func (context *outputContext) PopDiscard() {
 	}
 
 	context.stateStack = context.stateStack[:stateStackLen-1]
-
-	logOutput.Trace("state popped from stack (discarded)")
 }
 
 // ClearStateStack reinitializes the state stack.
 func (context *outputContext) ClearStateStack() {
 	context.stateStack = make([]*vmcommon.VMOutput, 0)
-	logOutput.Trace("state stack cleared")
 }
 
 // CensorVMOutput will cause the next executed SC to appear isolated, as if

--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -7,11 +7,14 @@ import (
 
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
 	"github.com/ElrondNetwork/arwen-wasm-vm/math"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core"
 	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
 )
 
 var _ arwen.OutputContext = (*outputContext)(nil)
+
+var logOutput = logger.GetOrCreate("arwen/output")
 
 type outputContext struct {
 	host        arwen.VMHost
@@ -68,6 +71,7 @@ func (context *outputContext) PushState() {
 	newState := newVMOutput()
 	mergeVMOutputs(newState, context.outputState)
 	context.stateStack = append(context.stateStack, newState)
+	logOutput.Trace("state pushed onto stack")
 }
 
 // PopSetActiveState removes the latest entry from the state stack and sets it as the current vm output
@@ -79,8 +83,9 @@ func (context *outputContext) PopSetActiveState() {
 
 	prevState := context.stateStack[stateStackLen-1]
 	context.stateStack = context.stateStack[:stateStackLen-1]
-
 	context.outputState = prevState
+
+	logOutput.Trace("state popped from stack (set as active state)")
 }
 
 // PopMergeActiveState merges the current state into the head of the stateStack,
@@ -100,6 +105,8 @@ func (context *outputContext) PopMergeActiveState() {
 	mergeVMOutputs(prevState, context.outputState)
 	context.outputState = newVMOutput()
 	mergeVMOutputs(context.outputState, prevState)
+
+	logOutput.Trace("state popped from stack (merged into active state)")
 }
 
 // PopDiscard removes the latest entry from the state stack, but maintaining
@@ -111,11 +118,14 @@ func (context *outputContext) PopDiscard() {
 	}
 
 	context.stateStack = context.stateStack[:stateStackLen-1]
+
+	logOutput.Trace("state popped from stack (discarded)")
 }
 
 // ClearStateStack reinitializes the state stack.
 func (context *outputContext) ClearStateStack() {
 	context.stateStack = make([]*vmcommon.VMOutput, 0)
+	logOutput.Trace("state stack cleared")
 }
 
 // CensorVMOutput will cause the next executed SC to appear isolated, as if
@@ -129,6 +139,8 @@ func (context *outputContext) CensorVMOutput() {
 	context.outputState.GasRemaining = 0
 	context.outputState.GasRefund = big.NewInt(0)
 	context.outputState.Logs = make([]*vmcommon.LogEntry, 0)
+
+	logOutput.Trace("state content censored")
 }
 
 // ResetGas will set to 0 all gas used from output accounts, in order
@@ -141,6 +153,8 @@ func (context *outputContext) ResetGas() {
 			outTransfer.GasLocked = 0
 		}
 	}
+
+	logOutput.Trace("state gas reset")
 }
 
 // GetOutputAccount returns the output account present at the given address,
@@ -222,6 +236,7 @@ func (context *outputContext) PrependFinish(data []byte) {
 // WriteLog creates a new LogEntry and appends it to the logs of the current output state.
 func (context *outputContext) WriteLog(address []byte, topics [][]byte, data []byte) {
 	if context.host.Runtime().ReadOnly() {
+		logOutput.Error("log entry", "error", "cannot write logs in readonly mode")
 		return
 	}
 
@@ -229,6 +244,7 @@ func (context *outputContext) WriteLog(address []byte, topics [][]byte, data []b
 		Address: address,
 		Data:    data,
 	}
+	logOutput.Trace("log entry", "address", address, "data", data)
 
 	if len(topics) == 0 {
 		context.outputState.Logs = append(context.outputState.Logs, newLogEntry)
@@ -239,26 +255,33 @@ func (context *outputContext) WriteLog(address []byte, topics [][]byte, data []b
 	newLogEntry.Topics = topics[1:]
 
 	context.outputState.Logs = append(context.outputState.Logs, newLogEntry)
+	logOutput.Trace("log entry", "identifier", newLogEntry.Identifier, "topics", newLogEntry.Topics)
 }
 
 // TransferValueOnly will transfer the big.int value and checks if it is possible
 func (context *outputContext) TransferValueOnly(destination []byte, sender []byte, value *big.Int) error {
+	logOutput.Trace("transfer value", "sender", sender, "dest", destination, "value", value)
+
 	if value.Cmp(arwen.Zero) < 0 {
+		logOutput.Trace("transfer value", "error", arwen.ErrTransferNegativeValue)
 		return arwen.ErrTransferNegativeValue
 	}
 
 	if !context.hasSufficientBalance(sender, value) {
+		logOutput.Trace("transfer value", "error", arwen.ErrTransferInsufficientFunds)
 		return arwen.ErrTransferInsufficientFunds
 	}
 
 	payable, err := context.host.Blockchain().IsPayable(destination)
 	if err != nil {
+		logOutput.Trace("transfer value", "error", err)
 		return err
 	}
 
 	isAsyncCall := context.host.IsArwenV3Enabled() && context.host.Runtime().GetVMInput().CallType == vmcommon.AsynchronousCall
 	hasValue := value.Cmp(big.NewInt(0)) == 1
 	if !payable && hasValue && !isAsyncCall {
+		logOutput.Trace("transfer value", "error", arwen.ErrAccountNotPayable)
 		return arwen.ErrAccountNotPayable
 	}
 
@@ -290,6 +313,7 @@ func (context *outputContext) Transfer(destination []byte, sender []byte, gasLim
 	}
 	destAcc.OutputTransfers = append(destAcc.OutputTransfers, outputTransfer)
 
+	logOutput.Trace("transfer value added")
 	return nil
 }
 
@@ -318,6 +342,7 @@ func (context *outputContext) TransferESDT(
 
 	if isExecution {
 		if gasRemaining > context.host.Metering().GasLeft() {
+			logOutput.Trace("ESDT post-transfer execution", "error", arwen.ErrNotEnoughGas)
 			return 0, arwen.ErrNotEnoughGas
 		}
 
@@ -442,7 +467,7 @@ func (context *outputContext) checkGas(remainedFromForwarded uint64) error {
 	totalGas, _ = math.SubUint64(totalGas, remainedFromForwarded)
 	totalGas, _ = math.SubUint64(totalGas, previousGasUsed)
 	if totalGas > gasProvided {
-		log.Error("gas usage mismatch", "total gas used", totalGas, "gas provided", gasProvided)
+		logOutput.Error("gas usage mismatch", "total gas used", totalGas, "gas provided", gasProvided)
 		return arwen.ErrInputAndOutputGasDoesNotMatch
 	}
 

--- a/arwen/contexts/output.go
+++ b/arwen/contexts/output.go
@@ -255,25 +255,25 @@ func (context *outputContext) TransferValueOnly(destination []byte, sender []byt
 	logOutput.Trace("transfer value", "sender", sender, "dest", destination, "value", value)
 
 	if value.Cmp(arwen.Zero) < 0 {
-		logOutput.Trace("transfer value", "error", arwen.ErrTransferNegativeValue)
+		logOutput.Error("transfer value", "error", arwen.ErrTransferNegativeValue)
 		return arwen.ErrTransferNegativeValue
 	}
 
 	if !context.hasSufficientBalance(sender, value) {
-		logOutput.Trace("transfer value", "error", arwen.ErrTransferInsufficientFunds)
+		logOutput.Error("transfer value", "error", arwen.ErrTransferInsufficientFunds)
 		return arwen.ErrTransferInsufficientFunds
 	}
 
 	payable, err := context.host.Blockchain().IsPayable(destination)
 	if err != nil {
-		logOutput.Trace("transfer value", "error", err)
+		logOutput.Error("transfer value", "error", err)
 		return err
 	}
 
 	isAsyncCall := context.host.IsArwenV3Enabled() && context.host.Runtime().GetVMInput().CallType == vmcommon.AsynchronousCall
 	hasValue := value.Cmp(big.NewInt(0)) == 1
 	if !payable && hasValue && !isAsyncCall {
-		logOutput.Trace("transfer value", "error", arwen.ErrAccountNotPayable)
+		logOutput.Error("transfer value", "error", arwen.ErrAccountNotPayable)
 		return arwen.ErrAccountNotPayable
 	}
 
@@ -334,7 +334,7 @@ func (context *outputContext) TransferESDT(
 
 	if isExecution {
 		if gasRemaining > context.host.Metering().GasLeft() {
-			logOutput.Trace("ESDT post-transfer execution", "error", arwen.ErrNotEnoughGas)
+			logOutput.Error("ESDT post-transfer execution", "error", arwen.ErrNotEnoughGas)
 			return 0, arwen.ErrNotEnoughGas
 		}
 

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -143,7 +143,7 @@ func (context *runtimeContext) makeInstanceFromCompiledCode(codeHash []byte, gas
 	blockchain := context.host.Blockchain()
 	found, compiledCode := blockchain.GetCompiledCode(codeHash)
 	if !found {
-		logRuntime.Trace("instance creation", "code", "cached compilation", "error", "compiled code was not found")
+		logRuntime.Error("instance creation", "code", "cached compilation", "error", "compiled code was not found")
 		return false
 	}
 

--- a/arwen/contexts/runtime.go
+++ b/arwen/contexts/runtime.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
 )
 
-var log = logger.GetOrCreate("arwen/runtime")
+var logRuntime = logger.GetOrCreate("arwen/runtime")
 
 var _ arwen.RuntimeContext = (*runtimeContext)(nil)
 
@@ -79,6 +79,8 @@ func (context *runtimeContext) InitState() {
 	context.asyncContextInfo = &arwen.AsyncContextInfo{
 		AsyncContextMap: make(map[string]*arwen.AsyncContext),
 	}
+
+	logRuntime.Trace("init state")
 }
 
 // ReplaceInstanceBuilder replaces the instance builder, allowing the creation
@@ -93,7 +95,7 @@ func (context *runtimeContext) setWarmInstanceWhenNeeded(gasLimit uint64) bool {
 	scAddress := context.GetSCAddress()
 	useWarm := context.useWarmInstance && context.warmInstanceAddress != nil && bytes.Equal(scAddress, context.warmInstanceAddress)
 	if scAddress != nil && useWarm {
-		log.Trace("Reusing the warm Wasmer instance")
+		logRuntime.Trace("reusing warm instance")
 
 		context.instance = context.warmInstance
 		context.SetPointsUsed(0)
@@ -106,49 +108,11 @@ func (context *runtimeContext) setWarmInstanceWhenNeeded(gasLimit uint64) bool {
 	return false
 }
 
-func (context *runtimeContext) makeInstanceFromCompiledCode(codeHash []byte, gasLimit uint64, newCode bool) bool {
-	if !context.host.IsAheadOfTimeCompileEnabled() {
-		return false
-	}
-
-	if newCode || len(codeHash) == 0 {
-		return false
-	}
-
-	blockchain := context.host.Blockchain()
-	found, compiledCode := blockchain.GetCompiledCode(codeHash)
-	if !found {
-		log.Debug("compiled code was not found")
-		return false
-	}
-
-	gasSchedule := context.host.Metering().GasSchedule()
-	options := wasmer.CompilationOptions{
-		GasLimit:           gasLimit,
-		UnmeteredLocals:    uint64(gasSchedule.WASMOpcodeCost.LocalsUnmetered),
-		OpcodeTrace:        false,
-		Metering:           true,
-		RuntimeBreakpoints: true,
-	}
-	newInstance, err := context.instanceBuilder.NewInstanceFromCompiledCodeWithOptions(compiledCode, options)
-	if err != nil {
-		log.Warn("NewInstanceFromCompiledCodeWithOptions", "error", err)
-		return false
-	}
-
-	context.instance = newInstance
-
-	idContext := arwen.AddHostContext(context.host)
-	context.instance.SetContextData(idContext)
-	context.verifyCode = false
-
-	return true
-}
-
 // StartWasmerInstance creates a new wasmer instance if the maxWasmerInstances has not been reached.
 func (context *runtimeContext) StartWasmerInstance(contract []byte, gasLimit uint64, newCode bool) error {
 	if context.RunningInstancesCount() >= context.maxWasmerInstances {
 		context.instance = nil
+		logRuntime.Error("create instance", "error", arwen.ErrMaxInstancesReached)
 		return arwen.ErrMaxInstancesReached
 	}
 
@@ -167,9 +131,47 @@ func (context *runtimeContext) StartWasmerInstance(contract []byte, gasLimit uin
 	return context.makeInstanceFromContractByteCode(contract, codeHash, gasLimit, newCode)
 }
 
-func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte, codeHash []byte, gasLimit uint64, newCode bool) error {
-	log.Trace("Creating a new Wasmer instance")
+func (context *runtimeContext) makeInstanceFromCompiledCode(codeHash []byte, gasLimit uint64, newCode bool) bool {
+	if !context.host.IsAheadOfTimeCompileEnabled() {
+		return false
+	}
 
+	if newCode || len(codeHash) == 0 {
+		return false
+	}
+
+	blockchain := context.host.Blockchain()
+	found, compiledCode := blockchain.GetCompiledCode(codeHash)
+	if !found {
+		logRuntime.Trace("instance creation", "code", "cached compilation", "error", "compiled code was not found")
+		return false
+	}
+
+	gasSchedule := context.host.Metering().GasSchedule()
+	options := wasmer.CompilationOptions{
+		GasLimit:           gasLimit,
+		UnmeteredLocals:    uint64(gasSchedule.WASMOpcodeCost.LocalsUnmetered),
+		OpcodeTrace:        false,
+		Metering:           true,
+		RuntimeBreakpoints: true,
+	}
+	newInstance, err := context.instanceBuilder.NewInstanceFromCompiledCodeWithOptions(compiledCode, options)
+	if err != nil {
+		logRuntime.Error("instance creation", "code", "cached compilation", "error", err)
+		return false
+	}
+
+	context.instance = newInstance
+
+	idContext := arwen.AddHostContext(context.host)
+	context.instance.SetContextData(idContext)
+	context.verifyCode = false
+
+	logRuntime.Trace("new instance created", "code", "cached compilation")
+	return true
+}
+
+func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte, codeHash []byte, gasLimit uint64, newCode bool) error {
 	gasSchedule := context.host.Metering().GasSchedule()
 	options := wasmer.CompilationOptions{
 		GasLimit:           gasLimit,
@@ -181,6 +183,7 @@ func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte,
 	newInstance, err := context.instanceBuilder.NewInstanceWithOptions(contract, options)
 	if err != nil {
 		context.instance = nil
+		logRuntime.Error("instance creation", "code", "bytecode", "error", err)
 		return err
 	}
 
@@ -190,6 +193,7 @@ func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte,
 		codeHash, err = context.host.Crypto().Sha256(contract)
 		if err != nil {
 			context.CleanWasmerInstance()
+			logRuntime.Error("instance creation", "code", "bytecode", "error", err)
 			return err
 		}
 	}
@@ -203,6 +207,7 @@ func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte,
 		err = context.VerifyContractCode()
 		if err != nil {
 			context.CleanWasmerInstance()
+			logRuntime.Error("instance creation", "code", "bytecode", "error", err)
 			return err
 		}
 	}
@@ -210,7 +215,10 @@ func (context *runtimeContext) makeInstanceFromContractByteCode(contract []byte,
 	if context.useWarmInstance {
 		context.warmInstanceAddress = context.GetSCAddress()
 		context.warmInstance = context.instance
+		logRuntime.Trace("updated warm instance")
 	}
+
+	logRuntime.Trace("new instance created", "code", "bytecode")
 
 	return nil
 }
@@ -235,7 +243,9 @@ func (context *runtimeContext) GetSCCodeSize() uint64 {
 func (context *runtimeContext) saveCompiledCode(codeHash []byte) {
 	compiledCode, err := context.instance.Cache()
 	if err != nil {
-		log.Error("getCompiledCode from instance", "error", err)
+		logRuntime.Error("getCompiledCode from instance", "error", err)
+
+		return
 	}
 
 	blockchain := context.host.Blockchain()
@@ -263,6 +273,7 @@ func (context *runtimeContext) ResetWarmInstance() {
 	context.instance = nil
 	context.warmInstanceAddress = nil
 	context.warmInstance = nil
+	logRuntime.Trace("warm instance cleaned")
 }
 
 // MustVerifyNextContractCode sets the verifyCode field to true
@@ -285,11 +296,14 @@ func (context *runtimeContext) InitStateFromContractCallInput(input *vmcommon.Co
 		CallerAddr:      input.CallerAddr,
 		AsyncContextMap: make(map[string]*arwen.AsyncContext),
 	}
+
+	logRuntime.Trace("init state from call input", "caller", input.CallerAddr)
 }
 
 // SetCustomCallFunction sets the given string as the callFunction field.
 func (context *runtimeContext) SetCustomCallFunction(callFunction string) {
 	context.callFunction = callFunction
+	logRuntime.Trace("set custom call function", "function", callFunction)
 }
 
 // PushState appends the current runtime state to the state stack; this
@@ -311,6 +325,8 @@ func (context *runtimeContext) PushState() {
 	// check is made to ensure that the running instance will not be cleaned
 	// while still required for execution.
 	context.pushInstance()
+
+	logRuntime.Trace("state pushed onto stack")
 }
 
 // PopSetActiveState removes the latest entry from the state stack and sets it as the current
@@ -331,6 +347,8 @@ func (context *runtimeContext) PopSetActiveState() {
 	context.asyncCallInfo = prevState.asyncCallInfo
 	context.asyncContextInfo = prevState.asyncContextInfo
 	context.popInstance()
+
+	logRuntime.Trace("state popped from stack (set as active state)")
 }
 
 // PopDiscard removes the latest entry from the state stack
@@ -342,16 +360,20 @@ func (context *runtimeContext) PopDiscard() {
 
 	context.stateStack = context.stateStack[:stateStackLen-1]
 	context.popInstance()
+
+	logRuntime.Trace("state popped from stack (discarded)")
 }
 
 // ClearStateStack reinitializes the state stack.
 func (context *runtimeContext) ClearStateStack() {
 	context.stateStack = make([]*runtimeContext, 0)
+	logRuntime.Trace("state stack cleared")
 }
 
 // pushInstance appends the current wasmer instance to the instance stack.
 func (context *runtimeContext) pushInstance() {
 	context.instanceStack = append(context.instanceStack, context.instance)
+	logRuntime.Trace("instance pushed onto stack")
 }
 
 // popInstance removes the latest entry from the wasmer instance stack and sets it
@@ -372,11 +394,13 @@ func (context *runtimeContext) popInstance() {
 		// current instance, so it cannot be cleaned, because the execution will
 		// resume on it. Popping will therefore only remove the top of the stack,
 		// without cleaning anything.
+		logRuntime.Trace("instance popped from stack (identical to prevInstance, no cleaning)")
 		return
 	}
 
 	context.CleanWasmerInstance()
 	context.instance = prevInstance
+	logRuntime.Trace("instance popped from stack")
 }
 
 // RunningInstancesCount returns the length of the instance stack.
@@ -506,6 +530,8 @@ func (context *runtimeContext) FailExecution(err error) {
 
 	context.host.Output().SetReturnMessage(message)
 	context.SetRuntimeBreakpointValue(arwen.BreakpointExecutionFailed)
+
+	logRuntime.Error("execution failed", "message", message)
 }
 
 // SignalUserError sets the returnMessage, returnCode and runtimeBreakpoint according an user error.
@@ -513,11 +539,13 @@ func (context *runtimeContext) SignalUserError(message string) {
 	context.host.Output().SetReturnCode(vmcommon.UserError)
 	context.host.Output().SetReturnMessage(message)
 	context.SetRuntimeBreakpointValue(arwen.BreakpointSignalError)
+	logRuntime.Error("user error signalled", "message", message)
 }
 
 // SetRuntimeBreakpointValue sets the given value as a breakpoint value.
 func (context *runtimeContext) SetRuntimeBreakpointValue(value arwen.BreakpointValue) {
 	context.instance.SetBreakpointValue(uint64(value))
+	logRuntime.Trace("runtime breakpoint set", "breakpoint", value)
 }
 
 // GetRuntimeBreakpointValue returns the breakpoint value for the current wasmer instance.
@@ -535,18 +563,23 @@ func (context *runtimeContext) VerifyContractCode() error {
 
 	err := context.validator.verifyMemoryDeclaration(context.instance)
 	if err != nil {
+		logRuntime.Error("verify contract code", "error", err)
 		return err
 	}
 
 	err = context.validator.verifyFunctions(context.instance)
 	if err != nil {
+		logRuntime.Error("verify contract code", "error", err)
 		return err
 	}
 
 	err = context.checkBackwardCompatibility()
 	if err != nil {
+		logRuntime.Error("verify contract code", "error", err)
 		return err
 	}
+
+	logRuntime.Trace("verified contract code")
 
 	return nil
 }
@@ -623,6 +656,8 @@ func (context *runtimeContext) CleanWasmerInstance() {
 	arwen.RemoveHostContext(*context.instance.GetData())
 	context.instance.Clean()
 	context.instance = nil
+
+	logRuntime.Trace("instance cleaned")
 }
 
 // IsContractOnTheStack iterates over the state stack to find whether the
@@ -639,11 +674,14 @@ func (context *runtimeContext) IsContractOnTheStack(address []byte) bool {
 // GetFunctionToCall returns the function to call from the wasmer instance exports.
 func (context *runtimeContext) GetFunctionToCall() (wasmer.ExportedFunctionCallback, error) {
 	exports := context.instance.GetExports()
+	logRuntime.Trace("get function to call", "function", context.callFunction)
 	if function, ok := exports[context.callFunction]; ok {
 		return function, nil
 	}
 
 	if context.callFunction == arwen.CallbackFunctionName {
+		// TODO rewrite this condition, until the AsyncContext is merged
+		logRuntime.Error("get function to call", "error", arwen.ErrNilCallbackFunction)
 		return nil, arwen.ErrNilCallbackFunction
 	}
 
@@ -687,6 +725,11 @@ func (context *runtimeContext) ExecuteAsyncCall(address []byte, data []byte, val
 	})
 	context.SetRuntimeBreakpointValue(arwen.BreakpointAsyncCall)
 
+	logRuntime.Trace("executing async call",
+		"caller", context.GetSCAddress(),
+		"dest", address,
+		"value", big.NewInt(0).SetBytes(value),
+		"data", data)
 	return nil
 }
 

--- a/arwen/contexts/storage.go
+++ b/arwen/contexts/storage.go
@@ -44,13 +44,11 @@ func NewStorageContext(
 
 // InitState does nothing
 func (context *storageContext) InitState() {
-	logStorage.Trace("init state")
 }
 
 // PushState appends the current address to the state stack.
 func (context *storageContext) PushState() {
 	context.stateStack = append(context.stateStack, context.address)
-	logStorage.Trace("state pushed onto stack")
 }
 
 // PopSetActiveState removes the latest entry from the state stack and sets it as the current address
@@ -64,8 +62,6 @@ func (context *storageContext) PopSetActiveState() {
 	context.stateStack = context.stateStack[:stateStackLen-1]
 
 	context.address = prevAddress
-
-	logStorage.Trace("state popped from stack (set as active state)")
 }
 
 // PopDiscard removes the latest entry from the state stack
@@ -76,14 +72,11 @@ func (context *storageContext) PopDiscard() {
 	}
 
 	context.stateStack = context.stateStack[:stateStackLen-1]
-
-	logStorage.Trace("state popped from stack (discarded)")
 }
 
 // ClearStateStack clears the state stack from the current context.
 func (context *storageContext) ClearStateStack() {
 	context.stateStack = make([][]byte, 0)
-	logStorage.Trace("state stack cleared")
 }
 
 // SetAddress sets the given address as the address for the current context.

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -629,7 +629,7 @@ func transferValueExecute(
 		logEEI.Trace("eGLD pre-transfer execution begin")
 		_, _, _, err = host.ExecuteOnDestContext(contractCallInput)
 		if arwen.WithFault(err, context, runtime.ElrondSyncExecAPIErrorShouldFailExecution()) {
-			logEEI.Trace("eGLD pre-transfer execution failed", "error", err)
+			logEEI.Error("eGLD pre-transfer execution failed", "error", err)
 			return 1
 		}
 
@@ -752,7 +752,7 @@ func transferESDTExecute(
 		logEEI.Trace("ESDT post-transfer execution begin")
 		_, _, _, err = host.ExecuteOnDestContext(contractCallInput)
 		if arwen.WithFault(err, context, runtime.ElrondSyncExecAPIErrorShouldFailExecution()) {
-			logEEI.Trace("ESDT post-transfer execution failed", "error", err)
+			logEEI.Error("ESDT post-transfer execution failed", "error", err)
 			host.RevertESDTTransfer(contractCallInput)
 			return 1
 		}

--- a/arwen/elrondapi/elrondei.go
+++ b/arwen/elrondapi/elrondei.go
@@ -82,9 +82,12 @@ import (
 	"github.com/ElrondNetwork/arwen-wasm-vm/arwen"
 	"github.com/ElrondNetwork/arwen-wasm-vm/math"
 	"github.com/ElrondNetwork/arwen-wasm-vm/wasmer"
+	logger "github.com/ElrondNetwork/elrond-go-logger"
 	"github.com/ElrondNetwork/elrond-go/core/parsers"
 	"github.com/ElrondNetwork/elrond-go/core/vmcommon"
 )
+
+var logEEI = logger.GetOrCreate("arwen/eei")
 
 // ElrondEIImports creates a new wasmer.Imports populated with the ElrondEI API methods
 func ElrondEIImports() (*wasmer.Imports, error) {
@@ -623,8 +626,10 @@ func transferValueExecute(
 	}
 
 	if host.AreInSameShard(send, dest) && contractCallInput != nil && host.Blockchain().IsSmartContract(dest) {
+		logEEI.Trace("eGLD pre-transfer execution begin")
 		_, _, _, err = host.ExecuteOnDestContext(contractCallInput)
 		if arwen.WithFault(err, context, runtime.ElrondSyncExecAPIErrorShouldFailExecution()) {
+			logEEI.Trace("eGLD pre-transfer execution failed", "error", err)
 			return 1
 		}
 
@@ -672,6 +677,7 @@ func transferESDT(
 
 	gasToUse = math.MulUint64(metering.GasSchedule().BaseOperationCost.PersistPerByte, uint64(length))
 	metering.UseGas(gasToUse)
+	logEEI.Warn("transferESDT() is deprecated")
 	// this is only for backward compatibility - function deprecated
 	return 1
 }
@@ -743,8 +749,10 @@ func transferESDTExecute(
 
 	if host.AreInSameShard(sender, dest) && contractCallInput != nil && host.Blockchain().IsSmartContract(dest) {
 		contractCallInput.GasProvided = gasLimitForExec
+		logEEI.Trace("ESDT post-transfer execution begin")
 		_, _, _, err = host.ExecuteOnDestContext(contractCallInput)
 		if arwen.WithFault(err, context, runtime.ElrondSyncExecAPIErrorShouldFailExecution()) {
+			logEEI.Trace("ESDT post-transfer execution failed", "error", err)
 			host.RevertESDTTransfer(contractCallInput)
 			return 1
 		}

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -788,6 +788,7 @@ func (host *vmHost) getFunctionByCallType(callType vmcommon.CallType) (wasmer.Ex
 
 	function, err := runtime.GetFunctionToCall()
 	if err != nil && !customCallback {
+		log.Error("get function by call type", "error", arwen.ErrNilCallbackFunction)
 		return nil, arwen.ErrNilCallbackFunction
 	}
 

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -15,17 +15,23 @@ import (
 )
 
 func (host *vmHost) handleAsyncCallBreakpoint() error {
+	log.Trace("async call begin")
 	runtime := host.Runtime()
 	runtime.SetRuntimeBreakpointValue(arwen.BreakpointNone)
 
 	asyncCallInfo := runtime.GetAsyncCallInfo()
 	execMode, err := host.determineAsyncCallExecutionMode(asyncCallInfo)
 	if err != nil {
+		log.Trace("async call failed", "error", err)
 		return err
 	}
 
+	log.Trace("async call", "execMode", execMode)
+
 	if execMode == arwen.AsyncUnknown {
-		return host.sendAsyncCallToDestination(asyncCallInfo)
+		err = host.sendAsyncCallToDestination(asyncCallInfo)
+		log.LogIfError(err, "async call failed: send cross-shard", "error", err)
+		return err
 	}
 
 	// Cross-shard calls for built-in functions must be executed in both the
@@ -35,12 +41,16 @@ func (host *vmHost) handleAsyncCallBreakpoint() error {
 		if err == nil && vmOutput.ReturnCode == vmcommon.Ok {
 			host.meteringContext.UseGas(gasUsedBeforeReset)
 		}
+		log.LogIfError(err, "async call failed: sync built-in", "error", err,
+			"retCode", vmOutput.ReturnCode,
+			"message", vmOutput.ReturnMessage)
 		return err
 	}
 
 	if execMode == arwen.ESDTTransferOnCallBack {
 		// return but keep async call info
 		host.outputContext.PrependFinish(asyncCallInfo.Data)
+		log.Trace("esdt transfer on callback")
 		return nil
 	}
 
@@ -108,10 +118,23 @@ func (host *vmHost) determineAsyncCallExecutionMode(asyncCallInfo *arwen.AsyncCa
 func (host *vmHost) executeSyncDestinationCall(asyncCallInfo arwen.AsyncCallInfoHandler) (*vmcommon.VMOutput, uint64, error) {
 	destinationCallInput, err := host.createDestinationContractCallInput(asyncCallInfo)
 	if err != nil {
+		log.Trace("async call: sync dest call failed", "error", err)
 		return nil, 0, err
 	}
 
+	log.Trace("async call: sync dest call",
+		"caller", destinationCallInput.CallerAddr,
+		"dest", destinationCallInput.RecipientAddr,
+		"func", destinationCallInput.Function,
+		"args", destinationCallInput.Arguments)
+
 	destinationVMOutput, _, gasUsedBeforeReset, err := host.ExecuteOnDestContext(destinationCallInput)
+
+	log.Trace("async call: sync dest call",
+		"retCode", destinationVMOutput.ReturnCode,
+		"message", destinationVMOutput.ReturnMessage,
+		"data", destinationVMOutput.ReturnData,
+		"error", err)
 	return destinationVMOutput, gasUsedBeforeReset, err
 }
 
@@ -134,8 +157,15 @@ func (host *vmHost) executeSyncCallbackCall(
 		destinationErr,
 	)
 	if err != nil {
+		log.Trace("async call: sync callback failed", "error", err)
 		return nil, err
 	}
+
+	log.Trace("async call: sync callback",
+		"caller", callbackCallInput.CallerAddr,
+		"dest", callbackCallInput.RecipientAddr,
+		"func", callbackCallInput.Function,
+		"args", callbackCallInput.Arguments)
 
 	gasConsumedForExecution := host.computeGasUsedInExecutionBeforeReset(callbackCallInput)
 	// used points should be reset before actually entering the callback execution
@@ -148,6 +178,11 @@ func (host *vmHost) executeSyncCallbackCall(
 		host.meteringContext.UseGas(gasConsumedForExecution)
 	}
 
+	log.Trace("async call: sync dest call",
+		"retCode", callbackVMOutput.ReturnCode,
+		"message", callbackVMOutput.ReturnMessage,
+		"data", callbackVMOutput.ReturnData,
+		"error", callBackErr)
 	return callbackVMOutput, callBackErr
 }
 

--- a/arwen/host/asyncCall.go
+++ b/arwen/host/asyncCall.go
@@ -22,7 +22,7 @@ func (host *vmHost) handleAsyncCallBreakpoint() error {
 	asyncCallInfo := runtime.GetAsyncCallInfo()
 	execMode, err := host.determineAsyncCallExecutionMode(asyncCallInfo)
 	if err != nil {
-		log.Trace("async call failed", "error", err)
+		log.Error("async call failed", "error", err)
 		return err
 	}
 
@@ -118,7 +118,7 @@ func (host *vmHost) determineAsyncCallExecutionMode(asyncCallInfo *arwen.AsyncCa
 func (host *vmHost) executeSyncDestinationCall(asyncCallInfo arwen.AsyncCallInfoHandler) (*vmcommon.VMOutput, uint64, error) {
 	destinationCallInput, err := host.createDestinationContractCallInput(asyncCallInfo)
 	if err != nil {
-		log.Trace("async call: sync dest call failed", "error", err)
+		log.Error("async call: sync dest call failed", "error", err)
 		return nil, 0, err
 	}
 
@@ -157,7 +157,7 @@ func (host *vmHost) executeSyncCallbackCall(
 		destinationErr,
 	)
 	if err != nil {
-		log.Trace("async call: sync callback failed", "error", err)
+		log.Error("async call: sync callback failed", "error", err)
 		return nil, err
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/ElrondNetwork/arwen-wasm-vm v1.1.1/go.mod h1:4fNkXf7kVgXfjdGzH0ErHEw4
 github.com/ElrondNetwork/big-int-util v0.0.5/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
 github.com/ElrondNetwork/big-int-util v0.1.0 h1:vTMoJ5azhVmr7jhpSD3JUjQdkdyXoEPVkOvhdw1RjV4=
 github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
+github.com/ElrondNetwork/concurrent-map v0.1.3 h1:j2LtPrNJuerannC1cQDE79STvi/P04gd61sNYo04Zf0=
 github.com/ElrondNetwork/concurrent-map v0.1.3/go.mod h1:3XwSwn4JHI0lrKxWLZvtp53Emr8BXYTmNQGwcukHJEE=
 github.com/ElrondNetwork/elrond-go v1.1.0/go.mod h1:R5HRN9NnnJ0gRd4QogmbUbQNTEczLsFCtfIgd3+3cYY=
 github.com/ElrondNetwork/elrond-go v1.1.6-0.20201113091116-de0c9a4e63c6/go.mod h1:dUNMqGg/jqTgHbnNxAmW7WkApWXlCQ8brVPbwIEFghI=
@@ -42,11 +43,13 @@ github.com/ElrondNetwork/elrond-vm-util v0.4.5/go.mod h1:YqFO7HkKfBnVQesisZuJ/Qc
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/StackExchange/wmi v0.0.0-20170410192909-ea383cf3ba6e/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIOA6tDi6QXUemppXK3P9BI7mr2hd6gx8=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
+github.com/beevik/ntp v0.3.0 h1:xzVrPrE4ziasFXgBVBZJDP0Wg/KpMwk2KHJ4Ba8GrDw=
 github.com/beevik/ntp v0.3.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/benbjohnson/clock v1.0.2/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
@@ -62,6 +65,7 @@ github.com/btcsuite/btcd v0.21.0-beta/go.mod h1:ZSWyehm27aAuS9bvkATT+Xte3hjHZ+MR
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190207003914-4c204d697803/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
@@ -101,6 +105,7 @@ github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70d
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elastic/go-elasticsearch/v7 v7.1.0 h1:BLm6CaiURXtycMTHpnJrx/zfoGbztMQi6XlcTwayJuU=
 github.com/elastic/go-elasticsearch/v7 v7.1.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -109,6 +114,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/cors v0.0.0-20190301062745-f9e10995c85a/go.mod h1:pL2kNE+DgDU+eQ+dary5bX0Z6LPP8nR6Mqs1iejILw4=
@@ -124,7 +130,9 @@ github.com/gizak/termui/v3 v3.1.0/go.mod h1:bXQEBkJpzxUAKf0+xq9MSWAvWZlE7c+aidmy
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-ole/go-ole v1.2.1 h1:2lOsA72HgjxAuMlKpFiCbHTvu44PIVkZ5hqm3RSdI/E=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
@@ -162,12 +170,14 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -193,6 +203,7 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/herumi/bls-go-binary v0.0.0-20200324054641-17de9ae04665 h1:JjL0D1N5aUwjgJKOxqGtDGf2q5m4PgVtlxjwZeYSVlA=
@@ -253,6 +264,7 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
@@ -267,9 +279,11 @@ github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/koron/go-ssdp v0.0.0-20191105050749-2e1c40ed0b5d/go.mod h1:5Ky9EC2xfoUKUor0Hjgi2BJhCSXJfMOFlmyYrVKGQMk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
@@ -493,8 +507,10 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.1/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
@@ -548,21 +564,25 @@ github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXS
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d/go.mod h1:IuKpRQcYE1Tfu+oAQqaLisqDeXgjyyltCfsaoYN18NQ=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
+github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
+github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -572,6 +592,7 @@ github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bA
 github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -587,7 +608,9 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v0.0.0-20190731134726-d80c43f9c984 h1:wsZAb4P8F7uQSwsnxE1gk9AHCcc5U0wvyDzcLwFY0Eo=
 github.com/shirou/gopsutil v0.0.0-20190731134726-d80c43f9c984/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
+github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
@@ -638,6 +661,7 @@ github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
+github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965 h1:1oFLiOyVl+W7bnBzGhf7BbIv9loSFQcieWWYIjLqcAw=
 github.com/syndtr/goleveldb v1.0.1-0.20190318030020-c3a204f8e965/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
@@ -733,6 +757,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200519113804-d87ec0cfa476/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -780,6 +805,7 @@ golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fq
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -805,6 +831,7 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -844,6 +871,7 @@ google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -852,6 +880,7 @@ gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/R
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/src-d/go-cli.v0 v0.0.0-20181105080154-d492247bbc0d/go.mod h1:z+K8VcOYVYcSwSjGebuDL6176A1XskgbtNl64NSg+n8=
 gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
This PR adds many calls to `log.Trace()` and `log.Error()` in many key moments of SC execution flow. Useful for local testnets and contract debugging. The EEI method `writeEventLog()` will now appear directly to `stdout` when the `LogLevel` is set appropriately.