### PR TITLE
fix

### DIFF
--- a/arwenmandos/stepCheckAccounts.go
+++ b/arwenmandos/stepCheckAccounts.go
@@ -290,7 +290,7 @@ func checkTokenInstances(
 					expectedInstance.Royalties.Original,
 					accountInstance.TokenMetaData.Royalties))
 			}
-			if !expectedInstance.Hash.Check(accountInstance.TokenMetaData.Hash) {
+			if bytes.Compare(accountInstance.TokenMetaData.Hash, bytes.Repeat([]byte{0}, 32)) != 0 && !expectedInstance.Hash.Check(accountInstance.TokenMetaData.Hash) {
 				errors = append(errors, fmt.Errorf("bad ESDT NFT Hash. Account: %s. Token: %s. Nonce: %d. Want: %s. Have: %d",
 					accountAddress,
 					tokenName,

--- a/test/mandos-self-test/account-set-check.scen.json
+++ b/test/mandos-self-test/account-set-check.scen.json
@@ -86,6 +86,52 @@
                     "code": ""
                 }
             }
+        },
+        {
+            "step": "setState",
+            "accounts": {
+                "address:the-address": {
+                    "nonce": "5",
+                    "balance": "150",
+                    "esdt": {
+                        "str:NFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "address:the-address"
+                                }
+                            ]
+                        }
+                    },
+                    "username": "str:theusername.elrond",
+                    "storage": {},
+                    "code": ""
+                }
+            }
+        },
+        {
+            "step": "checkState",
+            "accounts": {
+                "address:the-address": {
+                    "nonce": "5",
+                    "balance": "150",
+                    "esdt": {
+                        "str:NFT-123456": {
+                            "instances": [
+                                {
+                                    "nonce": "1",
+                                    "balance": "1",
+                                    "creator": "address:the-address"
+                                }
+                            ]
+                        }
+                    },
+                    "username": "str:theusername.elrond",
+                    "storage": {},
+                    "code": ""
+                }
+            }
         }
     ]
 }


### PR DESCRIPTION
Fixing and issue in mandos-go where an NFT with unspecified hash would throw an error like "want nil hash, have [0 0 0 ... 0 0]". This makes it so an empty hash in the "real" NFT doesn't throw this error. 