### PR TITLE
Hotfix leaky executionErr

### DIFF
--- a/arwen/host/breakpoints.go
+++ b/arwen/host/breakpoints.go
@@ -17,7 +17,7 @@ func (host *vmHost) handleBreakpointIfAny(executionErr error) error {
 		return err
 	}
 
-	return executionErr
+	return arwen.ErrExecutionFailed
 }
 
 func (host *vmHost) handleBreakpoint(breakpointValue arwen.BreakpointValue) error {

--- a/arwen/host/breakpoints.go
+++ b/arwen/host/breakpoints.go
@@ -17,6 +17,7 @@ func (host *vmHost) handleBreakpointIfAny(executionErr error) error {
 		return err
 	}
 
+	log.Trace("wasmer execution error", "err", executionErr)
 	return arwen.ErrExecutionFailed
 }
 

--- a/arwen/host/execution.go
+++ b/arwen/host/execution.go
@@ -75,7 +75,7 @@ func (host *vmHost) performCodeDeployment(input arwen.CodeDeployInput) (*vmcommo
 
 	err = runtime.StartWasmerInstance(input.ContractCode, metering.GetGasForExecution(), true)
 	if err != nil {
-		log.Debug("performCodeDeployment/StartWasmerInstance", "err", err)
+		log.Trace("performCodeDeployment/StartWasmerInstance", "err", err)
 		return nil, arwen.ErrContractInvalid
 	}
 
@@ -558,7 +558,7 @@ func (host *vmHost) executeUpgrade(input *vmcommon.ContractCallInput) error {
 
 	err = runtime.StartWasmerInstance(codeDeployInput.ContractCode, metering.GetGasForExecution(), true)
 	if err != nil {
-		log.Debug("performCodeDeployment/StartWasmerInstance", "err", err)
+		log.Trace("performCodeDeployment/StartWasmerInstance", "err", err)
 		return arwen.ErrContractInvalid
 	}
 


### PR DESCRIPTION
This PR ensures that `executionErr` coming from Wasmer cannot leak into Arwen's return message. Also changes some `log.Debug()` calls to `log.Trace()`.