### PR TITLE
Latest vm common v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ElrondNetwork/big-int-util v0.1.0
 	github.com/ElrondNetwork/elrond-go-logger v1.0.4
-	github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210707100510-6cef7cea933f
+	github.com/ElrondNetwork/elrond-vm-common v1.0.0
 	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/gin-gonic/gin v1.7.1
 	github.com/gogo/protobuf v1.3.2

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,4 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )
 
-replace github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.19 => github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210707101317-ce902fac190f
+replace github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.19 => github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210709082401-59813c456706

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ElrondNetwork/big-int-util v0.1.0 h1:vTMoJ5azhVmr7jhpSD3JUjQdkdyXoEPV
 github.com/ElrondNetwork/big-int-util v0.1.0/go.mod h1:96viBvoTXLjZOhEvE0D+QnAwg1IJLPAK6GVHMbC7Aw4=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4 h1:i5Yu4qyjTZDwvBY/ykbNpp2SP9jxwk/QTivRwSZSTAQ=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
-github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210707100510-6cef7cea933f h1:972J5HdUMwSCgOrBBh1guafiAAIaUCfblvfCT3I5NRU=
-github.com/ElrondNetwork/elrond-vm-common v0.3.4-0.20210707100510-6cef7cea933f/go.mod h1:7hBvPplhnrputKHXcrO0oZEdws87Exatc3PMt3XAL/k=
+github.com/ElrondNetwork/elrond-vm-common v1.0.0 h1:tE9+AFxy6yZSDF0OGjhAuU919UFZrtxN2BZJ8/rAlBk=
+github.com/ElrondNetwork/elrond-vm-common v1.0.0/go.mod h1:7hBvPplhnrputKHXcrO0oZEdws87Exatc3PMt3XAL/k=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.21.0-beta h1:At9hIZdJW0s9E/fAz28nrz6AmcNlSVucCH796ZteX1M=

--- a/test/egld-esdt-swap/mandos/wrap_egld.scen.json
+++ b/test/egld-esdt-swap/mandos/wrap_egld.scen.json
@@ -41,6 +41,14 @@
                 "logs": [
                     {
                         "address": "sc:egld-esdt-swap",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:WEGLD-abcdef", "500",  "address:user"
+                        ],
+                        "data": ""
+                    },
+                    {
+                        "address": "sc:egld-esdt-swap",
                         "identifier": "str:wrap-egld",
                         "topics": [
                             "address:user"

--- a/test/egld-esdt-swap/mandos/wrap_egld.scen.json
+++ b/test/egld-esdt-swap/mandos/wrap_egld.scen.json
@@ -43,7 +43,9 @@
                         "address": "sc:egld-esdt-swap",
                         "identifier": "str:ESDTTransfer",
                         "topics": [
-                            "str:WEGLD-abcdef", "500",  "address:user"
+                            "str:WEGLD-abcdef",
+                            "500",
+                            "address:user"
                         ],
                         "data": ""
                     },

--- a/test/features/composability/mandos/forw_raw_async_accept_esdt.scen.json
+++ b/test/features/composability/mandos/forw_raw_async_accept_esdt.scen.json
@@ -51,6 +51,16 @@
                 "status": "0",
                 "logs": [
                     {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:vault",
                         "identifier": "str:accept_funds",
                         "topics": [

--- a/test/features/composability/mandos/forw_raw_direct_esdt.scen.json
+++ b/test/features/composability/mandos/forw_raw_direct_esdt.scen.json
@@ -51,6 +51,16 @@
                 "logs": [
                     {
                         "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
+                        "address": "sc:forwarder",
                         "identifier": "str:callback_raw",
                         "topics": [
                             "str:EGLD",

--- a/test/features/composability/mandos/forwarder_call_async_accept_esdt.scen.json
+++ b/test/features/composability/mandos/forwarder_call_async_accept_esdt.scen.json
@@ -50,6 +50,16 @@
                 "status": "0",
                 "logs": [
                     {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:vault",
                         "identifier": "str:accept_funds",
                         "topics": [

--- a/test/features/composability/mandos/forwarder_call_async_retrieve_esdt.scen.json
+++ b/test/features/composability/mandos/forwarder_call_async_retrieve_esdt.scen.json
@@ -59,6 +59,16 @@
                         "data": ""
                     },
                     {
+                        "address": "sc:vault",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:forwarder"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:forwarder",
                         "identifier": "str:retrieve_funds_callback",
                         "topics": [

--- a/test/features/composability/mandos/forwarder_call_sync_accept_esdt.scen.json
+++ b/test/features/composability/mandos/forwarder_call_sync_accept_esdt.scen.json
@@ -55,6 +55,16 @@
                 "status": "0",
                 "logs": [
                     {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:vault",
                         "identifier": "str:accept_funds",
                         "topics": [

--- a/test/features/composability/mandos/forwarder_call_sync_accept_then_read_esdt.scen.json
+++ b/test/features/composability/mandos/forwarder_call_sync_accept_then_read_esdt.scen.json
@@ -50,6 +50,16 @@
                 "status": "0",
                 "logs": [
                     {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:vault",
                         "identifier": "str:accept_funds",
                         "topics": [

--- a/test/features/composability/mandos/forwarder_call_sync_retrieve_esdt.scen.json
+++ b/test/features/composability/mandos/forwarder_call_sync_retrieve_esdt.scen.json
@@ -57,6 +57,16 @@
                             "1000"
                         ],
                         "data": ""
+                    },
+                    {
+                        "address": "sc:vault",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:forwarder"
+                        ],
+                        "data": ""
                     }
                 ],
                 "gas": "*",

--- a/test/features/composability/mandos/forwarder_call_transf_exec_accept_esdt.scen.json
+++ b/test/features/composability/mandos/forwarder_call_transf_exec_accept_esdt.scen.json
@@ -50,6 +50,16 @@
                 "status": "0",
                 "logs": [
                     {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:vault",
                         "identifier": "str:accept_funds",
                         "topics": [

--- a/test/features/composability/mandos/forwarder_call_transf_exec_accept_esdt_twice.scen.json
+++ b/test/features/composability/mandos/forwarder_call_transf_exec_accept_esdt_twice.scen.json
@@ -50,6 +50,16 @@
                 "status": "0",
                 "logs": [
                     {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:vault",
                         "identifier": "str:accept_funds",
                         "topics": [
@@ -57,6 +67,16 @@
                             "str:FungibleESDT",
                             "1000",
                             "0"
+                        ],
+                        "data": ""
+                    },
+                    {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:TEST-TOKEN",
+                            "1000",
+                            "sc:vault"
                         ],
                         "data": ""
                     },

--- a/test/features/composability/mandos/forwarder_send_twice_esdt.scen.json
+++ b/test/features/composability/mandos/forwarder_send_twice_esdt.scen.json
@@ -48,6 +48,16 @@
                 "status": "0",
                 "logs": [
                     {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:FWD-TOKEN",
+                            "1",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:vault",
                         "identifier": "str:accept_funds",
                         "topics": [
@@ -55,6 +65,16 @@
                             "str:FungibleESDT",
                             "1",
                             "0"
+                        ],
+                        "data": ""
+                    },
+                    {
+                        "address": "sc:forwarder",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:FWD-TOKEN",
+                            "1",
+                            "sc:vault"
                         ],
                         "data": ""
                     },

--- a/test/features/composability/mandos/recursive_caller_esdt_1.scen.json
+++ b/test/features/composability/mandos/recursive_caller_esdt_1.scen.json
@@ -60,6 +60,16 @@
                         "data": "1"
                     },
                     {
+                        "address": "sc:recursive-caller",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:REC-TOKEN",
+                            "1",
+                            "sc:vault"
+                        ],
+                        "data": ""
+                    },
+                    {
                         "address": "sc:vault",
                         "identifier": "str:accept_funds",
                         "topics": [

--- a/test/features/composability/mandos/send_esdt.scen.json
+++ b/test/features/composability/mandos/send_esdt.scen.json
@@ -64,7 +64,18 @@
             "expect": {
                 "out": [],
                 "status": "",
-                "logs": []
+                "logs": [
+                    {
+                        "address": "sc:basic-features",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:BASIC-FEATURES-TOKEN",
+                            "100",
+                            "address:an_account"
+                        ],
+                        "data": ""
+                    }
+                ]
             }
         },
         {
@@ -87,7 +98,18 @@
             "expect": {
                 "out": [],
                 "status": "",
-                "logs": []
+                "logs": [
+                    {
+                        "address": "sc:basic-features",
+                        "identifier": "str:ESDTTransfer",
+                        "topics": [
+                            "str:BASIC-FEATURES-TOKEN",
+                            "100",
+                            "address:an_account"
+                        ],
+                        "data": ""
+                    }
+                ]
             }
         },
         {


### PR DESCRIPTION
Use the latest release on the [elrond-vm-common](https://github.com/ElrondNetwork/elrond-vm-common/tree/v1.0.0) repository.
In this new release, all the` fungible ESDT operations `will generate a log with details about the operation that is executed.

Fixed mandos tests.