### PR TITLE
Remove 'replace' from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,3 @@ require (
 	github.com/urfave/cli v1.22.5
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )
-
-replace github.com/ElrondNetwork/arwen-wasm-vm/v1_3 v1.3.19 => github.com/ElrondNetwork/arwen-wasm-vm v1.3.20-0.20210709082401-59813c456706


### PR DESCRIPTION
This PR removes the `replace` directive from `go.mod`. It is not necessary anymore.