### PR TITLE
fix gasCost for GenerateKey

### DIFF
--- a/arwenmandos/gasSchedules/gasScheduleV3.toml
+++ b/arwenmandos/gasSchedules/gasScheduleV3.toml
@@ -172,7 +172,7 @@
     MarshalCompressedECC   = 15000
     UnmarshalECC           = 20000
     UnmarshalCompressedECC = 270000
-    GenerateKeyECC         = 700000
+    GenerateKeyECC         = 7000000
 
 [ManagedBufferAPICost]
     MBufferNew                   = 2000


### PR DESCRIPTION
there was a missing '0' in gasCost