### PR TITLE
Refactored secp256k1 to allow different hash types

### DIFF
--- a/arwen/cryptoapi/cryptoei.go
+++ b/arwen/cryptoapi/cryptoei.go
@@ -436,7 +436,9 @@ func v1_4_encodeSecp256k1DerSignature(
 
 	derSig := crypto.EncodeSecp256k1DERSignature(r, s)
 	err = runtime.MemStore(sigOffset, derSig)
-	_ = arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution())
+	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
+		return 1
+	}
 
 	return 0
 }

--- a/arwen/cryptoapi/cryptoei.go
+++ b/arwen/cryptoapi/cryptoei.go
@@ -436,7 +436,7 @@ func v1_4_encodeSecp256k1DerSignature(
 
 	derSig := crypto.EncodeSecp256k1DERSignature(r, s)
 	err = runtime.MemStore(sigOffset, derSig)
-	if arwen.WithFault(err, context, runtime.ElrondAPIErrorShouldFailExecution()) {
+	if arwen.WithFault(err, context, runtime.CryptoAPIErrorShouldFailExecution()) {
 		return 1
 	}
 

--- a/arwen/cryptoapi/cryptoei.go
+++ b/arwen/cryptoapi/cryptoei.go
@@ -12,6 +12,8 @@ package cryptoapi
 // extern int32_t v1_4_verifyBLS(void *context, int32_t keyOffset, int32_t messageOffset, int32_t messageLength, int32_t sigOffset);
 // extern int32_t v1_4_verifyEd25519(void *context, int32_t keyOffset, int32_t messageOffset, int32_t messageLength, int32_t sigOffset);
 // extern int32_t v1_4_verifySecp256k1(void *context, int32_t keyOffset, int32_t keyLength, int32_t messageOffset, int32_t messageLength, int32_t sigOffset);
+// extern int32_t v1_4_verifyCustomSecp256k1(void *context, int32_t keyOffset, int32_t keyLength, int32_t messageOffset, int32_t messageLength, int32_t sigOffset, int32_t hashType);
+// extern int32_t v1_4_encodeSecp256k1DerSignature(void *context, int32_t rOffset, int32_t rLength, int32_t sOffset, int32_t sLength, int32_t sigOffset);
 // extern void v1_4_addEC(void *context, int32_t xResultHandle, int32_t yResultHandle, int32_t ecHandle, int32_t fstPointXHandle, int32_t fstPointYHandle, int32_t sndPointXHandle, int32_t sndPointYHandle);
 // extern void v1_4_doubleEC(void *context, int32_t xResultHandle, int32_t yResultHandle, int32_t ecHandle, int32_t pointXHandle, int32_t pointYHandle);
 // extern int32_t v1_4_isOnCurveEC(void *context, int32_t ecHandle, int32_t pointXHandle, int32_t pointYHandle);
@@ -76,6 +78,16 @@ func CryptoImports(imports *wasmer.Imports) (*wasmer.Imports, error) {
 	}
 
 	imports, err = imports.Append("verifySecp256k1", v1_4_verifySecp256k1, C.v1_4_verifySecp256k1)
+	if err != nil {
+		return nil, err
+	}
+
+	imports, err = imports.Append("verifyCustomSecp256k1", v1_4_verifyCustomSecp256k1, C.v1_4_verifyCustomSecp256k1)
+	if err != nil {
+		return nil, err
+	}
+
+	imports, err = imports.Append("encodeSecp256k1DerSignature", v1_4_encodeSecp256k1DerSignature, C.v1_4_encodeSecp256k1DerSignature)
 	if err != nil {
 		return nil, err
 	}

--- a/arwenmandos/gasSchedules/gasScheduleV3.toml
+++ b/arwenmandos/gasSchedules/gasScheduleV3.toml
@@ -173,6 +173,7 @@
     UnmarshalECC           = 20000
     UnmarshalCompressedECC = 270000
     GenerateKeyECC         = 7000000
+    EncodeDERSig           = 1000000
 
 [ManagedBufferAPICost]
     MBufferNew                   = 2000

--- a/arwenmandos/gasSchedules/tomlfiles.go
+++ b/arwenmandos/gasSchedules/tomlfiles.go
@@ -1402,6 +1402,7 @@ gasScheduleV3 = `[BuiltInCost]
     UnmarshalECC           = 20000
     UnmarshalCompressedECC = 270000
     GenerateKeyECC         = 7000000
+    EncodeDERSig           = 1000000
 
 [ManagedBufferAPICost]
     MBufferNew                   = 2000

--- a/config/config.toml
+++ b/config/config.toml
@@ -134,6 +134,7 @@
     UnmarshalECC           = 10
     UnmarshalCompressedECC = 10
     GenerateKeyECC         = 10
+    EncodeDERSig           = 10
 
 [ManagedBufferAPICost]
     MBufferNew                   = 10

--- a/config/gasCost.go
+++ b/config/gasCost.go
@@ -157,6 +157,7 @@ type CryptoAPICost struct {
 	UnmarshalECC           uint64
 	UnmarshalCompressedECC uint64
 	GenerateKeyECC         uint64
+	EncodeDERSig           uint64
 }
 
 type ManagedBufferAPICost struct {

--- a/config/gasSchedule.go
+++ b/config/gasSchedule.go
@@ -320,6 +320,7 @@ func FillGasMap_CryptoAPICosts(value uint64) map[string]uint64 {
 	gasMap["UnmarshalECC"] = value
 	gasMap["UnmarshalCompressedECC"] = value
 	gasMap["GenerateKeyECC"] = value
+	gasMap["EncodeDERSig"] = value
 
 	return gasMap
 }

--- a/crypto/interface.go
+++ b/crypto/interface.go
@@ -20,7 +20,8 @@ type Ed25519 interface {
 }
 
 type Secp256k1 interface {
-	VerifySecp256k1(key []byte, msg []byte, sig []byte) error
+	VerifySecp256k1(key []byte, msg []byte, sig []byte, hashType uint8) error
+	EncodeSecp256k1DERSignature(r, s []byte) []byte
 }
 
 // VMCrypto will provide the interface to the main crypto functionalities of the vm

--- a/crypto/signing/errors.go
+++ b/crypto/signing/errors.go
@@ -9,3 +9,6 @@ var ErrInvalidPublicKey = errors.New("public key is invalid")
 
 // ErrInvalidSignature will be returned when ed25519 signature verification fails
 var ErrInvalidSignature = errors.New("invalid signature")
+
+// ErrHasherNotSupported will be returned when a provided hasher type is not supported by the signature scheme
+var ErrHasherNotSupported = errors.New("invalid signature")

--- a/crypto/signing/secp256k1/secp256k1.go
+++ b/crypto/signing/secp256k1/secp256k1.go
@@ -1,9 +1,22 @@
 package secp256k1
 
 import (
+	"math/big"
+
+	"github.com/ElrondNetwork/arwen-wasm-vm/v1_4/crypto/hashing"
 	"github.com/ElrondNetwork/arwen-wasm-vm/v1_4/crypto/signing"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+type MessageHashType uint8
+const (
+	ECDSAPlainMsg MessageHashType = iota
+	ECDSASha256
+	ECDSADoubleSha256
+	ECDSAKeccak256
+	ECDSARipemd160
 )
 
 type secp256k1 struct {
@@ -13,8 +26,15 @@ func NewSecp256k1() *secp256k1 {
 	return &secp256k1{}
 }
 
-func (sec *secp256k1) VerifySecp256k1(key []byte, msg []byte, sig []byte) error {
+// VerifySecp256k1 checks a secp256k1 signature provided in the DER encoding format.
+// The hash type used over the message can also be configured using @param hashType
+func (sec *secp256k1) VerifySecp256k1(key, msg, sig []byte, hashType uint8) error {
 	pubKey, err := btcec.ParsePubKey(key, btcec.S256())
+	if err != nil {
+		return err
+	}
+
+	messageHash, err := sec.hashMessage(msg, hashType)
 	if err != nil {
 		return err
 	}
@@ -24,12 +44,49 @@ func (sec *secp256k1) VerifySecp256k1(key []byte, msg []byte, sig []byte) error 
 		return err
 	}
 
-	messageHash := chainhash.DoubleHashB(msg)
 	verified := signature.Verify(messageHash, pubKey)
-
 	if !verified {
 		return signing.ErrInvalidSignature
 	}
 
 	return nil
+}
+
+// EncodeDERSecp256k1Signature creates a DER encoding of a signature provided with r and s.
+// Useful when having the plain params - like in the case of ecrecover
+//  from ethereum
+func (sec *secp256k1) EncodeSecp256k1DERSignature(r, s []byte) []byte {
+	sig := &btcec.Signature{
+		R: big.NewInt(0).SetBytes(r),
+		S: big.NewInt(0).SetBytes(s),
+	}
+
+	return sig.Serialize()
+}
+
+func (sec *secp256k1) hashMessage(msg []byte, hashType uint8) ([]byte, error) {
+	hasher := hashing.NewHasher()
+
+	var err error
+	var hashedMsg []byte
+	switch MessageHashType(hashType) {
+	case ECDSASha256:
+		hashedMsg, err = hasher.Sha256(msg)
+	case ECDSADoubleSha256:
+		hashedMsg = chainhash.DoubleHashB(msg)
+	case ECDSAKeccak256:
+		hashedMsg, err = hasher.Keccak256(msg)
+	case ECDSARipemd160:
+		hashedMsg, err = hasher.Ripemd160(msg)
+	case ECDSAPlainMsg:
+		hashedMsg = msg
+	default:
+		return nil, signing.ErrHasherNotSupported
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return hashedMsg, nil
 }

--- a/crypto/signing/secp256k1/secp256k1_test.go
+++ b/crypto/signing/secp256k1/secp256k1_test.go
@@ -14,7 +14,7 @@ func TestEthereumSig(t *testing.T) {
 	key, _ := hex.DecodeString("04e32df42865e97135acfb65f3bae71bdc86f4d49150ad6a440b6f15878109880a0a2b2667f7e725ceea70c673093bf67663e0312623c8e091b13cf2c0f11ef652")
 
 	verifier := NewSecp256k1()
-	sig := verifier.EncodeSignature(r, s)
+	sig := verifier.EncodeSecp256k1DERSignature(r, s)
 	err := verifier.VerifySecp256k1(key, msg, sig, byte(ECDSAPlainMsg))
 
 	assert.Nil(t, err)
@@ -27,7 +27,7 @@ func TestBitcoinSig(t *testing.T) {
 	s, _ := hex.DecodeString("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f")
 
 	verifier := NewSecp256k1()
-	sig := verifier.EncodeSignature(r, s)
+	sig := verifier.EncodeSecp256k1DERSignature(r, s)
 	err := verifier.VerifySecp256k1(pubKey, msg, sig, byte(ECDSADoubleSha256))
 
 	assert.Nil(t, err)

--- a/crypto/signing/secp256k1/secp256k1_test.go
+++ b/crypto/signing/secp256k1/secp256k1_test.go
@@ -1,0 +1,34 @@
+package secp256k1
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEthereumSig(t *testing.T) {
+	msg, _ := hex.DecodeString("ce0677bb30baa8cf067c88db9811f4333d131bf8bcf12fe7065d211dce971008")
+	r, _ := hex.DecodeString("90f27b8b488db00b00606796d2987f6a5f59ae62ea05effe84fef5b8b0e54998")
+	s, _ := hex.DecodeString("4a691139ad57a3f0b906637673aa2f63d1f55cb1a69199d4009eea23ceaddc93")
+	key, _ := hex.DecodeString("04e32df42865e97135acfb65f3bae71bdc86f4d49150ad6a440b6f15878109880a0a2b2667f7e725ceea70c673093bf67663e0312623c8e091b13cf2c0f11ef652")
+
+	verifier := NewSecp256k1()
+	sig := verifier.EncodeSignature(r, s)
+	err := verifier.VerifySecp256k1(key, msg, sig, byte(ECDSAPlainMsg))
+
+	assert.Nil(t, err)
+}
+
+func TestBitcoinSig(t *testing.T) {
+	pubKey, _ := hex.DecodeString("04d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdabab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52")
+	msg, _ := hex.DecodeString("01020304")
+	r, _ := hex.DecodeString("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c")
+	s, _ := hex.DecodeString("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f")
+
+	verifier := NewSecp256k1()
+	sig := verifier.EncodeSignature(r, s)
+	err := verifier.VerifySecp256k1(pubKey, msg, sig, byte(ECDSADoubleSha256))
+
+	assert.Nil(t, err)
+}

--- a/mock/context/cryptoMock.go
+++ b/mock/context/cryptoMock.go
@@ -32,8 +32,13 @@ func (c *CryptoHookMock) VerifyEd25519(key []byte, msg []byte, sig []byte) error
 }
 
 // VerifySecp256k1 mocked method
-func (c *CryptoHookMock) VerifySecp256k1(key []byte, msg []byte, sig []byte, hashType byte) error {
+func (c *CryptoHookMock) VerifySecp256k1(key []byte, msg []byte, sig []byte, hashType uint8) error {
 	return c.Err
+}
+
+// EncodeSecp256k1DERSignature mocked method
+func (c *CryptoHookMock) EncodeSecp256k1DERSignature(r, s []byte) []byte {
+	return make([]byte, 0)
 }
 
 // Ecrecover mocked method

--- a/mock/context/cryptoMock.go
+++ b/mock/context/cryptoMock.go
@@ -32,7 +32,7 @@ func (c *CryptoHookMock) VerifyEd25519(key []byte, msg []byte, sig []byte) error
 }
 
 // VerifySecp256k1 mocked method
-func (c *CryptoHookMock) VerifySecp256k1(key []byte, msg []byte, sig []byte) error {
+func (c *CryptoHookMock) VerifySecp256k1(key []byte, msg []byte, sig []byte, hashType byte) error {
 	return c.Err
 }
 


### PR DESCRIPTION
Refactored secp256k1 to allow different hash types

Two new hooks were added:
`v1_4_verifyCustomSecp256k1`
`v1_4_encodeSecp256k1DerSignature` - allows SC devs to encode `r` and `s` into DER standard